### PR TITLE
LDES for linked connections on `/connections/feed`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ server_config.json
 .coveralls.yml
 .rt_indexes
 ecosystem.config.js
+.idea

--- a/lib/data/connections-feed.js
+++ b/lib/data/connections-feed.js
@@ -46,12 +46,10 @@ class ConnectionsFeed {
             const path = `${utils.datasetsConfig['storage']}/feed_history/${this.agency}`;
             await Promise.all(fragments.map(async f => {
                 const fragment_date = new Date(f.substring(0, f.indexOf('.json')));
-                const conns = JSON.parse(await readFile(`${path}/${fragment_date.toISOString()}.json`));
-                console.log("inserting into AVL tree:", fragment_date.getTime());
-                this.avlTree.insert(fragment_date.getTime(), conns);
+                this.avlTree.insert(fragment_date.getTime(), JSON.parse(await readFile(`${path}/${fragment_date.toISOString()}.json`)));
             }));
 
-            logger.info(`Created AVL Tree for ${this.agency} (took ${(new Date().getTime() - start.getTime())} ms)`);
+            logger.info(`Created feed AVL Tree for ${this.agency} (took ${(new Date().getTime() - start.getTime())} ms)`);
             logger.debug(`Number of RT fragments inserted in ${this.agency} AVL Tree: ${fragments.length}`);
 
             // Check for real-time updates by watching the latest.json file for real-time updates
@@ -84,9 +82,7 @@ class ConnectionsFeed {
         }
 
         // sort the list from newest to oldest date
-        fragments.sort((a, b) => {
-            return new Date(b) - new Date(a);
-        });
+        fragments.sort();
 
         return fragments;
     }
@@ -101,10 +97,11 @@ class ConnectionsFeed {
             }
             const fragments = await this.getSortedFragments();
             // if tree is not full, just insert
-            const newFragment = JSON.parse(await readFile(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${fragments[0]}`));
-            const newFragmentDate = new Date(newFragment.substring(0, newFragment.indexOf('.json')));
-            this.avlTree.insert(newFragmentDate.getTime(), newFragment);
-            this.RTData.insertRTFragments(this.agency, newFragment);
+            const latestFragment = fragments[fragments.length - 1];
+            const newFragmentData = JSON.parse(await readFile(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${latestFragment}`));
+            const newFragmentDate = new Date();
+            this.avlTree.insert(newFragmentDate.getTime(), newFragmentData);
+            this.RTData.insertRTFragments(this.agency, latestFragment);
 
             logger.debug(`-----------Update ${this.agency} AVL Tree-------------`);
             logger.debug(`Load live data from disk took ${(new Date().getTime() - t0.getTime())} ms`);

--- a/lib/data/connections-feed.js
+++ b/lib/data/connections-feed.js
@@ -99,7 +99,7 @@ class ConnectionsFeed {
             // if tree is not full, just insert
             const latestFragment = fragments[fragments.length - 1];
             const newFragmentData = JSON.parse(await readFile(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${latestFragment}`));
-            const newFragmentDate = new Date();
+            const newFragmentDate = new Date(latestFragment.substring(0, latestFragment.indexOf(".json")));
             this.avlTree.insert(newFragmentDate.getTime(), newFragmentData);
             this.RTData.insertRTFragments(this.agency, latestFragment);
 

--- a/lib/data/connections-feed.js
+++ b/lib/data/connections-feed.js
@@ -1,0 +1,217 @@
+const fs = require('fs');
+const util = require('util');
+const watch = require('node-watch');
+const utils = require('../utils/utils');
+const AVLTree = require('../utils/avl-tree');
+const Logger = require('../utils/logger');
+
+const writeFile = util.promisify(fs.writeFile);
+const readFile = util.promisify(fs.readFile);
+const readdir = util.promisify(fs.readdir);
+const logger = Logger.getLogger(utils.serverConfig.logLevel || 'info');
+
+class ConnectionsFeed {
+    constructor(options) {
+        this._agency = options['agency'];
+        this._staticData = options['staticData'];
+        this._avlTree = new AVLTree();
+        this._delayIndex = {};
+        this._min = null;
+        this._max = null;
+        this._watcher = null;
+        this._recreateJob = null;
+        this._latestVersion = null;
+        this._numberOfFragments = 100;
+    }
+
+    async init() {
+        try {
+            const start = new Date();
+
+            // Make sure we start fresh
+            this.clear();
+
+            // Create AVL Tree which will consist the 100 most recent fragments
+
+            // get list of current fragments in feed_history
+            let fragments = await this.getSortedFragments();
+
+            // if necessary, cut the list down to 100 fragments
+            fragments.splice(this._numberOfFragments);
+
+            // load the ordered fragments and insert them into AVL tree
+            const path = `${utils.datasetsConfig['storage']}/feed_history/${this.agency}`;
+            await Promise.all(fragments.map(async f => {
+                const fragment_date = new Date(f.substring(0, f.indexOf('.json')));
+                const conns = JSON.parse(await readFile(`${path}/${fragment_date.toISOString()}.json`));
+                console.log("inserting into AVL tree:", fragment_date.getTime());
+                this.avlTree.insert(fragment_date.getTime(), conns);
+            }));
+
+            // if necessary, insert more static files to fill the AVL tree
+            let staticFragmentCount = 0;
+            if (fragments.length < this._numberOfFragments) {
+                const amount_of_static_data = this._numberOfFragments - fragments.length;
+
+                // get static data from now until 'amount_of_static_data' fragments in the future
+                const now = new Date();
+                const versions = utils.sortVersions(now, Object.keys(this.staticData.staticFragments[this.agency]));
+                const [staticVersion, fr, index] = utils.findResource(this.agency, now.getTime(), versions, this.staticData.staticFragments);
+                const staticFragments = this.staticData['staticFragments'][this.agency][staticVersion].slice(index, index + amount_of_static_data);
+                this.min = staticFragments[0];
+                this.max = staticFragments[staticFragments.length - 1];
+                const path = `${utils.datasetsConfig['storage']}/linked_pages/${this.agency}/${staticVersion}`;
+
+                // insert the static data into the AVL tree
+                await Promise.all(staticFragments.map(async f => {
+                    console.log("f:", f);
+                    const fragment_date = new Date(f);
+                    console.log("fragment_date:", fragment_date);
+                    const conns = JSON.parse('['+await utils.readAndGunzip(`${path}/${fragment_date.toISOString()}.jsonld.gz`)+']');
+                    console.log("inserting into AVL tree (static):", fragment_date.getTime());
+                    this.avlTree.insert(fragment_date.getTime(), conns)
+                    staticFragmentCount += 1;
+                }));
+            }
+
+            logger.info(`Created AVL Tree for ${this.agency} (took ${(new Date().getTime() - start.getTime())} ms)`);
+            logger.debug(`Number of Connections inserted in ${this.agency} AVL Tree: ${fragments.length + staticFragmentCount} total (${fragments.length} RT, ${staticFragmentCount} static)`);
+
+            // Check for real-time updates by watching the latest.json file for real-time updates
+            const latest = `${utils.datasetsConfig['storage']}/real_time/${this.agency}/latest.json`;
+            if (!fs.existsSync(latest)) {
+                await writeFile(latest, 'await for rt update', 'utf8');
+            }
+
+            // add watcher that checks for updates in latest.json
+            this.watcher = watch(latest, (event, filename) => {
+                if (filename && event === 'update') {
+                    this.handleUpdate();
+                }
+            });
+
+        } catch (err) {
+            logger.error(err);
+            console.error(err);
+        }
+    }
+
+    async getSortedFragments() {
+        // get list of current fragments in feed_history
+        let fragments = await readdir(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}`);
+
+        // remove 'latest.json' if it exists
+        const latestIndex = fragments.indexOf("latest.json");
+        if (latestIndex > -1) {
+            fragments.splice(latestIndex, 1);
+        }
+
+        // sort the list from newest to oldest date
+        fragments.sort((a, b) => {
+            return new Date(b) - new Date(a);
+        });
+
+        return fragments;
+    }
+
+    async handleUpdate() {
+        try {
+            let t0 = new Date();
+            // check if AVL tree is 'full'
+            if (this.avlTree.size >= this.numberOfFragments) {
+                // if tree is full, delete oldest fragment
+                this.avlTree.remove(this.avlTree.min(), this.avlTree.minNode())
+            }
+            const fragments = await this.getSortedFragments();
+            // if tree is not full, just insert
+            const newFragment = JSON.parse(await readFile(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${fragments[0]}`));
+            const newFragmentDate = new Date(newFragment.substring(0, newFragment.indexOf('.json')));
+            this.avlTree.insert(newFragmentDate.getTime(), newFragment);
+
+            logger.debug(`-----------Update ${this.agency} AVL Tree-------------`);
+            logger.debug(`Load live data from disk took ${(new Date().getTime() - t0.getTime())} ms`);
+        } catch (err) {
+            logger.error(err);
+            console.error(err);
+        }
+    }
+
+    clear() {
+        this.avlTree.clear();
+        this.delayIndex = {};
+        this.min = null;
+        this.max = null;
+        this.recreateJob = null;
+        this.watcher = null;
+    }
+
+    get agency() {
+        return this._agency;
+    }
+
+    get staticData() {
+        return this._staticData;
+    }
+
+    get avlTree() {
+        return this._avlTree;
+    }
+
+    get delayIndex() {
+        return this._delayIndex;
+    }
+
+    set delayIndex(index) {
+        this._delayIndex = index;
+    }
+
+    get min() {
+        return this._min;
+    }
+
+    set min(min) {
+        this._min = min;
+    }
+
+    get max() {
+        return this._max;
+    }
+
+    set max(max) {
+        this._max = max;
+    }
+
+    get watcher() {
+        return this._watcher;
+    }
+
+    set watcher(watcher) {
+        this._watcher = watcher;
+    }
+
+    get recreateJob() {
+        return this._recreateJob;
+    }
+
+    set recreateJob(job) {
+        this._recreateJob = job;
+    }
+
+    get latestVersion() {
+        return this._latestVersion;
+    }
+
+    set latestVersion(newVersion) {
+        this._latestVersion = newVersion;
+    }
+
+    get numberOfFragments() {
+        return this._numberOfFragments;
+    }
+
+    set numberOfFragments(numberOfFragments) {
+        this._numberOfFragments = numberOfFragments;
+    }
+}
+
+module.exports = ConnectionsFeed;

--- a/lib/data/connections-feed.js
+++ b/lib/data/connections-feed.js
@@ -4,6 +4,8 @@ const watch = require('node-watch');
 const utils = require('../utils/utils');
 const AVLTree = require('../utils/avl-tree');
 const Logger = require('../utils/logger');
+// const RealTimeData = require('../data/real-time')
+// const StaticData = require('../data/static');
 
 const writeFile = util.promisify(fs.writeFile);
 const readFile = util.promisify(fs.readFile);
@@ -14,6 +16,7 @@ class ConnectionsFeed {
     constructor(options) {
         this._agency = options['agency'];
         this._staticData = options['staticData'];
+        this._RTData = options['RTData'];
         this._avlTree = new AVLTree();
         this._delayIndex = {};
         this._min = null;
@@ -48,34 +51,8 @@ class ConnectionsFeed {
                 this.avlTree.insert(fragment_date.getTime(), conns);
             }));
 
-            // if necessary, insert more static files to fill the AVL tree
-            let staticFragmentCount = 0;
-            if (fragments.length < this._numberOfFragments) {
-                const amount_of_static_data = this._numberOfFragments - fragments.length;
-
-                // get static data from now until 'amount_of_static_data' fragments in the future
-                const now = new Date();
-                const versions = utils.sortVersions(now, Object.keys(this.staticData.staticFragments[this.agency]));
-                const [staticVersion, fr, index] = utils.findResource(this.agency, now.getTime(), versions, this.staticData.staticFragments);
-                const staticFragments = this.staticData['staticFragments'][this.agency][staticVersion].slice(index, index + amount_of_static_data);
-                this.min = staticFragments[0];
-                this.max = staticFragments[staticFragments.length - 1];
-                const path = `${utils.datasetsConfig['storage']}/linked_pages/${this.agency}/${staticVersion}`;
-
-                // insert the static data into the AVL tree
-                await Promise.all(staticFragments.map(async f => {
-                    console.log("f:", f);
-                    const fragment_date = new Date(f);
-                    console.log("fragment_date:", fragment_date);
-                    const conns = JSON.parse('['+await utils.readAndGunzip(`${path}/${fragment_date.toISOString()}.jsonld.gz`)+']');
-                    console.log("inserting into AVL tree (static):", fragment_date.getTime());
-                    this.avlTree.insert(fragment_date.getTime(), conns)
-                    staticFragmentCount += 1;
-                }));
-            }
-
             logger.info(`Created AVL Tree for ${this.agency} (took ${(new Date().getTime() - start.getTime())} ms)`);
-            logger.debug(`Number of Connections inserted in ${this.agency} AVL Tree: ${fragments.length + staticFragmentCount} total (${fragments.length} RT, ${staticFragmentCount} static)`);
+            logger.debug(`Number of RT fragments inserted in ${this.agency} AVL Tree: ${fragments.length}`);
 
             // Check for real-time updates by watching the latest.json file for real-time updates
             const latest = `${utils.datasetsConfig['storage']}/real_time/${this.agency}/latest.json`;
@@ -127,6 +104,7 @@ class ConnectionsFeed {
             const newFragment = JSON.parse(await readFile(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${fragments[0]}`));
             const newFragmentDate = new Date(newFragment.substring(0, newFragment.indexOf('.json')));
             this.avlTree.insert(newFragmentDate.getTime(), newFragment);
+            this.RTData.insertRTFragments(this.agency, newFragment);
 
             logger.debug(`-----------Update ${this.agency} AVL Tree-------------`);
             logger.debug(`Load live data from disk took ${(new Date().getTime() - t0.getTime())} ms`);
@@ -211,6 +189,10 @@ class ConnectionsFeed {
 
     set numberOfFragments(numberOfFragments) {
         this._numberOfFragments = numberOfFragments;
+    }
+
+    get RTData() {
+        return this._RTData
     }
 }
 

--- a/lib/data/connections.js
+++ b/lib/data/connections.js
@@ -20,6 +20,7 @@ class Connections {
         this._max = null;
         this._watcher = null;
         this._recreateJob = null;
+        this._latestVersion = null;
     }
 
     async init() {
@@ -48,6 +49,9 @@ class Connections {
             logger.info(`Created AVL Tree for ${this.agency} (took ${(new Date().getTime() - t0.getTime())} ms)`);
             logger.debug(`Number of Connections inserted in ${this.agency} AVL Tree: ${connCount}`);
             logger.debug(`Time window of the ${this.agency} tree: ${(this.max - this.min) / (1000 * 60)} minutes`);
+
+            // Register the creation version for this connections source
+            this.latestVersion = new Date();
 
             // Check for real-time updates by watching the latest.json file of real-time updates
             if (utils.getCompanyDatasetConfig(this.agency)['realTimeData']) {
@@ -122,10 +126,12 @@ class Connections {
                             this.avlTree.insert(curr, conn);
                         }
                     }
-                    // Register the last know departure delay for this connection so we can find it again
+                    // Register the last known departure delay for this connection so we can find it again
                     this.delayIndex[conn['@id']] = conn['departureDelay'];
                 }
             }));
+
+            this.latestVersion = new Date();
             logger.debug(`Reorganize tree nodes took ${(new Date().getTime() - t0.getTime())} ms`);
         } catch (err) {
             logger.error(err);
@@ -192,6 +198,14 @@ class Connections {
 
     set recreateJob(job) {
         this._recreateJob = job;
+    }
+
+    get latestVersion() {
+        return this._latestVersion;
+    }
+
+    set latestVersion(newVersion) {
+        this._latestVersion = newVersion;
     }
 }
 

--- a/lib/data/real-time.js
+++ b/lib/data/real-time.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const util = require('util');
+const utils = require('../utils/utils');
+
+const readdir = util.promisify(fs.readdir);
+
+
+class RealTimeData {
+    /**
+     * construct a RealTimeData object that keeps an index of all real-time files
+     * @param storage
+     * @param datasets
+     */
+    constructor(storage, datasets) {
+        this._storage = `${storage}/feed_history/`;
+        this._datasets = datasets;
+        this._RTFragments = {};
+    }
+
+    /**
+     * read all of the files in 'feed_history' and index the filenames into this.RTFragments
+     */
+    async initRTFragments() {
+        // Iterate over all companies
+        for (let i in this.datasets) {
+            let companyName = this.datasets[i].companyName;
+            // Object for keeping fragment scan
+            if (!this.RTFragments[companyName]) {
+                this.RTFragments[companyName] = {};
+                let dir = await readdir(this.storage + companyName);
+                let arr = [];
+                // Keep each fragment in milliseconds since epoch in the scan
+                for (let fragment of dir) {
+                    // check if file is 'latest.json'
+                    if (!(fragment === 'latest.json')) {
+                        // convert filename to epoch time
+                        let fragment_date = new Date(fragment.substring(0, fragment.indexOf('.json')));
+                        arr.push(fragment_date.getTime());
+                    }
+                }
+                if (arr.length > 0) {
+                    //sort the array
+                    arr.sort((a, b) => {
+                        return new Date(b) - new Date(a);
+                    });
+                    this.RTFragments[companyName] = arr;
+                }
+            }
+        }
+    }
+
+    /**
+     * add newly created files to the 'RTFragments' index. To make sure that the array of fragments is still sorted
+     * after insertion, you should only insert new fragments.
+     * @param companyName name of agency where we inserted the new RT fragment
+     * @param fragment file name of the new fragment (ISO 8601 creation date with '.json' extension)
+     */
+    insertRTFragments(companyName, fragment) {
+        let fragment_date = new Date(fragment.substring(0, fragment.indexOf('.json')));
+        if (!(fragment_date in this.RTFragments[companyName])){
+            this.RTFragments.push(fragment_date.getTime());
+        }
+    }
+
+    get storage() {
+        return this._storage;
+    }
+
+    get datasets() {
+        return this._datasets;
+    }
+
+    get RTFragments() {
+        return this._RTFragments;
+    }
+}
+
+module.exports = RealTimeData;

--- a/lib/data/real-time.js
+++ b/lib/data/real-time.js
@@ -40,9 +40,7 @@ class RealTimeData {
                 }
                 if (arr.length > 0) {
                     //sort the array
-                    arr.sort((a, b) => {
-                        return new Date(b) - new Date(a);
-                    });
+                    arr.sort();
                     this.RTFragments[companyName] = arr;
                 }
             }
@@ -57,9 +55,7 @@ class RealTimeData {
      */
     insertRTFragments(companyName, fragment) {
         let fragment_date = new Date(fragment.substring(0, fragment.indexOf('.json')));
-        if (!(fragment_date in this.RTFragments[companyName])){
-            this.RTFragments.push(fragment_date.getTime());
-        }
+        this.RTFragments[companyName].push(fragment_date.getTime());
     }
 
     get storage() {

--- a/lib/manager/dataset_manager.js
+++ b/lib/manager/dataset_manager.js
@@ -62,6 +62,10 @@ class DatasetManager {
             fs.mkdirSync(this.storage + '/catalog');
         }
 
+        if (!fs.existsSync(this.storage + '/feed_history')) {
+            fs.mkdirSync(this.storage + '/feed_history');
+        }
+
         if (!fs.existsSync(this.storage + '/linked_connections')) {
             fs.mkdirSync(this.storage + '/linked_connections');
         }
@@ -128,6 +132,10 @@ class DatasetManager {
 
         if (!fs.existsSync(this.storage + '/catalog/' + name)) {
             fs.mkdirSync(this.storage + '/catalog/' + name);
+        }
+
+        if (!fs.existsSync(this.storage + '/feed_history/' + name)) {
+            fs.mkdirSync(this.storage + '/feed_history/' + name);
         }
 
         if (!fs.existsSync(this.storage + '/linked_connections/' + name)) {
@@ -344,8 +352,18 @@ class DatasetManager {
 
                 rtlc.on('end', async () => {
                     try {
+                        console.log("We should write now");
+
+                        // write data to buffer (a buffer is just a json file named after the current time, and will
+                        // contain the newest update)
+                        const now = new Date();
+                        await writeFile(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}.json`, JSON.stringify(rawData), 'utf8');
+                        // now, write the new data from the buffer to 'latest.json'
+                        fs.copyFileSync(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}.json`, `${this.storage}/feed_history/${dataset['companyName']}/latest.json`);
+
                         // Write to disk the complete list of updated Connections
                         await writeFile(`${this.storage}/real_time/${dataset['companyName']}/latest.json`, JSON.stringify(rawData), 'utf8');
+
                         // Update rt fragments
                         await Promise.all(rawData.map(async jodata => {
                             // Determine current fragment that the connection belongs to, due to delays

--- a/lib/manager/dataset_manager.js
+++ b/lib/manager/dataset_manager.js
@@ -352,8 +352,6 @@ class DatasetManager {
 
                 rtlc.on('end', async () => {
                     try {
-                        console.log("We should write now");
-
                         // write data to buffer (a buffer is just a json file named after the current time, and will
                         // contain the newest update)
                         const now = new Date();

--- a/lib/routes/feed.js
+++ b/lib/routes/feed.js
@@ -1,19 +1,322 @@
 const util = require('util');
 const fs = require('fs');
 const utils = require('../utils/utils');
+const accepts = require('accepts');
+const ConnectionsFeed = require('../data/connections-feed');
+const StaticData = require('../data/static');
+const RealTimeData = require('../data/real-time');
 
 const readFile = util.promisify(fs.readFile);
 const readdir = util.promisify(fs.readdir);
 const writeFile = util.promisify(fs.writeFile);
 
-class Feed{
+const logger = Logger.getLogger(server_config.logLevel || 'info');
+const storage = utils.datasetsConfig.storage;
+const mimeTypes = [
+    'application/json',
+    'application/ld+json',
+    'text/turtle',
+    'application/n-triples',
+    'application/n-quads',
+    'application/trig'
+];
+
+let feedTrees = {};
+const staticData = new StaticData(storage, utils.datasetsConfig['datasets']);
+const RTData = new RealTimeData(storage, utils.datasetsConfig['datasets']);
+
+class Feed {
     constructor() {
         this._storage = utils.datasetsConfig.storage;
         this._datasets = utils.datasetsConfig.datasets;
         this._serverConfig = utils.serverConfig;
     }
 
+    async init() {
+        // Create static fragments index structure
+        await staticData.updateStaticFragments(); // TODO check if this can be done concurrently with initRTFragments()
+        await RTData.initRTFragments();
+        // Create an AVL tree-based index of Connections for every data source
+        for (const d of this.datasets) {
+            const tree = new ConnectionsFeed({ staticData: staticData, RTData: RTData, agency: d['companyName'] });
+            await tree.init();
+            feedTrees[d['companyName']] = tree;
+        }
+    }
+
     async getFeed(req, res) {
+        // Allow requests from different hosts
+        res.set({ 'Access-Control-Allow-Origin': '*' });
+
+        // Determine protocol (i.e. HTTP or HTTPS)
+        let x_forwarded_proto = req.headers['x-forwarded-proto'];
+        let protocol = '';
+
+        if (typeof x_forwarded_proto == 'undefined' || x_forwarded_proto == '') {
+            if (typeof server_config.protocol == 'undefined' || server_config.protocol == '') {
+                protocol = 'http';
+            } else {
+                protocol = server_config.protocol;
+            }
+        } else {
+            protocol = x_forwarded_proto;
+        }
+
+        const host = protocol + '://' + server_config.hostname + '/';
+
+        // Request path and query parameters
+        const agency = req.params.agency;
+        let created = new Date(decodeURIComponent(req.query.created));
+        let version = new Date(decodeURIComponent(req.query.version));
+
+        // WARNING: storage should not end on a /
+        // TODO: use path to avoid OS compatibility issues and handle the trailing slash
+        // Check if there is data for the requested company
+        if (!fs.existsSync(storage + '/feed_history/' + agency)) {
+            res.set({ 'Cache-Control': 'immutable' });
+            res.status(404).send("Agency not found");
+            return;
+        }
+
+        // Accept header
+        const accept = accepts(req).type(mimeTypes);
+
+        // Redirect to NOW time in case provided date is invalid
+        if (created.toString() === 'Invalid Date') {
+            // Just save to a variable, a redirect will automatically follow since this won't perfectly resolve to an existing page
+            created = new Date();
+        }
+
+        // Redirect to proper URL if final / is given before params
+        if (req.url.indexOf('connections/feed/') >= 0) {
+            res.location(`/${agency}/connections/feed?created=${created.toISOString()}`);
+            res.status(302).send();
+            return;
+        }
+
+        try {
+            // Find the fragment that covers the requested time
+            let t0 = new Date();
+
+            // search the closest fragment to the left of the 'created' parameter (first in RT, then in static files
+            // if necessary)
+            let found_fragment, index, is_static;
+            let result = utils.findRTResource(agency, created, RTData.RTFragments);
+            if (result === null) {
+                found_fragment = result[0];
+                index = result[1];
+                is_static = false;
+            } else {
+                // look in the static files
+                let versions = Object.keys(staticData.staticFragments[agency]).sort();
+                // TODO
+            }
+            logger.debug('finding fragment took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+
+
+            let found_fragment_date = new Date(found_fragment);
+
+            // Redirect client to the appropriate fragment URL
+            if (created.getTime() !== found_fragment) {
+                res.location('/' + agency + '/connections/feed?created=' + found_fragment_date.toISOString());
+                res.status(302).send();
+                return;
+            }
+
+            let tree = feedTrees[agency].avlTree;
+            // check if fragment is in AVL tree
+            if (created.getTime() >= tree.min() && created.getTime() < tree.max()) {
+                let node = tree.find(created.getTime());
+            }
+            else {
+                // if it is not in the AVL tree, get it from the directory.
+
+                let rt_min = RTData.RTFragments[agency][0];
+                let rt_max = RTData.RTFragments[agency][RTData.RTFragments[agency].length - 1];
+                let static_min = staticData.staticFragments[agency][static_version][0];
+                // let static_max = staticData.staticFragments[agency][static_version][staticData.staticFragments[agency][static_version].length - 1];
+
+                // this fragment can either be a real-time fragment from 'feed_history', or a static fragment from
+                // 'linked_pages'.
+                if (created.getTime() >= rt_min && created.getTime() <= rt_max) {
+                    // the fragment is in 'feed_history'
+
+                } else if (created.getTime() >= static_min) {
+                    // the fragment is in 'linked_pages'
+
+                } else {
+                    // fragment cannot be found, so send 404
+                    res.status(404).send();
+                    return;
+                }
+
+            }
+
+
+
+
+
+
+            // Array that will contain all the Connections of this fragment
+            let jsonldGraph = [];
+            let lowLimit = found_fragment;
+            let highLimit = staticData.staticFragments[agency][static_version][index + 1];
+
+            // Check if the in-memory AVL Tree contains this fragment
+            if (departureTime.getTime() >= connTrees[agency].min && departureTime.getTime() < connTrees[agency].max) {
+                t0 = new Date()
+                const tree = connTrees[agency].avlTree;
+                const node = tree.find(found_fragment);
+                let prev = tree.prev(node);
+                let next = tree.next(node);
+
+                jsonldGraph.push(node.data);
+
+                // Complete connection departing at the same time
+                while (prev && prev.key === lowLimit) {
+                    jsonldGraph.push(prev.data);
+                    prev = tree.prev(prev);
+                }
+
+                // Add all connections until the beginning of the next fragment
+                while (next && next.key < highLimit) {
+                    jsonldGraph.push(next.data);
+                    next = tree.next(next);
+                }
+                logger.debug('Build fragment from AVL Tree took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+
+                // Set cache headers
+                const conf = utils.getCompanyDatasetConfig(agency);
+                if (conf['realTimeData']) {
+                    // Valid until the next update + 1 second to allow intermediate caches to update
+                    const rtUpdatePeriod = conf['realTimeData']['updatePeriod'];
+                    const validUntilDate = utils.getNextUpdate(rtUpdatePeriod);
+                    const maxage = Math.round((validUntilDate - now) / 1000);
+                    res.set({ 'Cache-Control': 'public, s-maxage=' + maxage + ', max-age=' + (maxage + 1)
+                            + ', stale-if-error=' + (maxage + 15) + ', proxy-revalidate' });
+                    res.set({ 'Expires': validUntilDate.toUTCString() });
+                } else {
+                    // Data is static so it can be cached for long time
+                    res.set({ 'Cache-Control': 'public, max-age=31536000000, immutable' });
+                    res.set({ 'Expires': new Date(now.getTime() + 31536000000).toUTCString() });
+                }
+
+            } else {
+                // Build fragment by loading static and live connections (if available) from disk
+                let sf_path = storage + '/linked_pages/' + agency + '/' + static_version + '/';
+                let rt_exists = false;
+
+                // Get all real-time fragments and remove_files needed to cover the requested static fragment
+                t0 = new Date();
+                let [rtfs, rtfs_remove] = utils.findRTData(agency, lowLimit, highLimit);
+                logger.debug('findRTData() took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+
+                if (rtfs.length > 0) {
+                    // There are real-time data fragments available for this request
+                    rt_exists = true;
+                }
+
+                // Check if this is a conditional get request, and if so check if we can close this request with a 304
+                if (rt_exists) {
+                    if (utils.handleConditionalGET(agency, req, res, accept, rtfs[rtfs.length - 1], true, departureTime)) {
+                        return;
+                    }
+                } else {
+                    if (utils.handleConditionalGET(agency, req, res, accept, sf_path, false, departureTime)) {
+                        return;
+                    }
+                }
+
+                // Get respective static data fragment according to departureTime query
+                // and complement resource with Real-Time data and Hydra metadata before sending it back to the client
+                t0 = new Date();
+                let static_buffer = await utils.readAndGunzip(sf_path + ff.toISOString() + '.jsonld.gz');
+                jsonldGraph = static_buffer.split(',\n').map(JSON.parse);
+                logger.debug('Read and process static fragment took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+
+                // Get real time data for this agency and requested time
+                if (rt_exists || rtfs_remove.length > 0) {
+                    let rt_data = [];
+
+                    t0 = new Date();
+                    await Promise.all(rtfs.map(async rt => {
+                        let rt_buffer = [];
+                        if (rt.indexOf('.gz') > 0) {
+                            rt_buffer.push((await utils.readAndGunzip(rt)));
+                        } else {
+                            rt_buffer.push((await readfile(rt, 'utf8')));
+                        }
+                        rt_data.push(rt_buffer.toString().split('\n'));
+                    }));
+                    logger.debug('Load all RT fragments (' + rtfs.length + ') took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+
+                    // Combine static and real-time data
+                    t0 = new Date();
+                    logger.debug('-----------aggregateRTData()-----------');
+                    jsonldGraph = await utils.aggregateRTData(jsonldGraph, rt_data, rtfs_remove, lowLimit, highLimit, now);
+                    logger.debug('---------------------------------------');
+                    logger.debug('aggregateRTData() took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+                }
+            }
+
+            const params = {
+                host: host,
+                agency: agency,
+                departureTime: ff,
+                version: static_version,
+                index: index,
+                data: jsonldGraph,
+                staticFragments: staticData.staticFragments
+            };
+
+
+
+            let final_data = await utils.addHydraMetada(params);
+
+            res.set({ 'Vary': 'Accept, Accept-Encoding, Accept-Datetime' });
+
+            switch (accept) {
+                case 'application/json':
+                    res.set({ 'Content-Type': 'application/ld+json' });
+                    res.status(200).send(final_data);
+                    break;
+                case 'application/ld+json':
+                    res.set({ 'Content-Type': 'application/ld+json' });
+                    res.status(200).send(final_data);
+                    break;
+                case 'text/turtle':
+                    res.set({ 'Content-Type': 'application/trig' });
+                    res.status(200).send(await utils.jsonld2RDF(final_data, 'text/turtle'));
+                    break;
+                case 'application/n-triples':
+                    res.set({ 'Content-Type': 'application/n-quads' });
+                    res.status(200).send(await utils.jsonld2RDF(final_data, 'application/n-triples'));
+                    break;
+                case 'application/n-quads':
+                    res.set({ 'Content-Type': 'application/n-quads' });
+                    res.status(200).send(await utils.jsonld2RDF(final_data, 'application/n-quads'));
+                    break;
+                case 'application/trig':
+                    res.set({ 'Content-Type': 'application/trig' });
+                    res.status(200).send(await utils.jsonld2RDF(final_data, 'application/trig'));
+                    break;
+                default:
+                    res.set({ 'Content-Type': 'application/ld+json' });
+                    res.status(200).send(final_data);
+                    break;
+            }
+
+            t0 = new Date();
+            logger.debug('Add Metadata took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+
+        } catch (err) {
+            if (err) {
+                logger.error(err);
+                console.error(err);
+            };
+            res.set({ 'Cache-Control': 'no-cache' });
+            res.status(404).send();
+        }
 
     }
 
@@ -29,11 +332,11 @@ class Feed{
         }
     }
 
-    get storage(){
+    get storage() {
         return this._storage;
     }
 
-    get datasets(){
+    get datasets() {
         return this._datasets
     }
 }

--- a/lib/routes/feed.js
+++ b/lib/routes/feed.js
@@ -5,12 +5,12 @@ const accepts = require('accepts');
 const ConnectionsFeed = require('../data/connections-feed');
 const StaticData = require('../data/static');
 const RealTimeData = require('../data/real-time');
+const Logger = require("../utils/logger");
 
 const readFile = util.promisify(fs.readFile);
-const readdir = util.promisify(fs.readdir);
-const writeFile = util.promisify(fs.writeFile);
+const server_config = utils.serverConfig;
 
-const logger = Logger.getLogger(server_config.logLevel || 'info');
+const logger = Logger.getLogger(utils.serverConfig.logLevel || 'info');
 const storage = utils.datasetsConfig.storage;
 const mimeTypes = [
     'application/json',
@@ -38,7 +38,7 @@ class Feed {
         await RTData.initRTFragments();
         // Create an AVL tree-based index of Connections for every data source
         for (const d of this.datasets) {
-            const tree = new ConnectionsFeed({ staticData: staticData, RTData: RTData, agency: d['companyName'] });
+            const tree = new ConnectionsFeed({staticData: staticData, RTData: RTData, agency: d['companyName']});
             await tree.init();
             feedTrees[d['companyName']] = tree;
         }
@@ -46,7 +46,7 @@ class Feed {
 
     async getFeed(req, res) {
         // Allow requests from different hosts
-        res.set({ 'Access-Control-Allow-Origin': '*' });
+        res.set({'Access-Control-Allow-Origin': '*'});
 
         // Determine protocol (i.e. HTTP or HTTPS)
         let x_forwarded_proto = req.headers['x-forwarded-proto'];
@@ -67,13 +67,13 @@ class Feed {
         // Request path and query parameters
         const agency = req.params.agency;
         let created = new Date(decodeURIComponent(req.query.created));
-        let version = new Date(decodeURIComponent(req.query.version));
+        // query can have a departureTime if and only if we request static data
+        let departure_time = new Date(decodeURIComponent(req.query.departureTime));
 
-        // WARNING: storage should not end on a /
         // TODO: use path to avoid OS compatibility issues and handle the trailing slash
-        // Check if there is data for the requested company
-        if (!fs.existsSync(storage + '/feed_history/' + agency)) {
-            res.set({ 'Cache-Control': 'immutable' });
+        // Check if there is static and real-time data for the requested company
+        if (!fs.existsSync(`${storage}/feed_history/${agency}`) || !fs.existsSync(`${storage}/linked_pages/${agency}`)) {
+            res.set({'Cache-Control': 'immutable'});
             res.status(404).send("Agency not found");
             return;
         }
@@ -83,7 +83,8 @@ class Feed {
 
         // Redirect to NOW time in case provided date is invalid
         if (created.toString() === 'Invalid Date') {
-            // Just save to a variable, a redirect will automatically follow since this won't perfectly resolve to an existing page
+            // Just save to a variable, a redirect will automatically follow since this won't
+            // perfectly resolve to an existing page
             created = new Date();
         }
 
@@ -97,230 +98,169 @@ class Feed {
         try {
             // Find the fragment that covers the requested time
             let t0 = new Date();
-
-            // search the closest fragment to the left of the 'created' parameter (first in RT, then in static files
-            // if necessary)
-            let found_fragment, index, is_static;
-            let result = utils.findRTResource(agency, created, RTData.RTFragments);
-            if (result === null) {
-                found_fragment = result[0];
-                index = result[1];
-                is_static = false;
-            } else {
-                // look in the static files
-                let versions = Object.keys(staticData.staticFragments[agency]).sort();
-                // TODO
-            }
+            let [found_fragment, index, is_static] = utils.findFeedResource(agency, created.getTime(), RTData.RTFragments, staticData.staticFragments);
             logger.debug('finding fragment took ' + (new Date().getTime() - t0.getTime()) + ' ms');
 
-
-            let found_fragment_date = new Date(found_fragment);
-
             // Redirect client to the appropriate fragment URL
+            console.log("times:", created.getTime(), found_fragment);
             if (created.getTime() !== found_fragment) {
+                let found_fragment_date = new Date(found_fragment);
                 res.location('/' + agency + '/connections/feed?created=' + found_fragment_date.toISOString());
                 res.status(302).send();
                 return;
             }
 
+            // find and retrieve the actual data contained in that fragment
+            let members, id, previous, next, latest, next_departure;
+            members = id = previous = next = latest = next_departure = null;
             let tree = feedTrees[agency].avlTree;
-            // check if fragment is in AVL tree
-            if (created.getTime() >= tree.min() && created.getTime() < tree.max()) {
-                let node = tree.find(created.getTime());
-            }
-            else {
-                // if it is not in the AVL tree, get it from the directory.
-
-                let rt_min = RTData.RTFragments[agency][0];
-                let rt_max = RTData.RTFragments[agency][RTData.RTFragments[agency].length - 1];
-                let static_min = staticData.staticFragments[agency][static_version][0];
-                // let static_max = staticData.staticFragments[agency][static_version][staticData.staticFragments[agency][static_version].length - 1];
-
-                // this fragment can either be a real-time fragment from 'feed_history', or a static fragment from
-                // 'linked_pages'.
-                if (created.getTime() >= rt_min && created.getTime() <= rt_max) {
-                    // the fragment is in 'feed_history'
-
-                } else if (created.getTime() >= static_min) {
-                    // the fragment is in 'linked_pages'
-
+            // get latest page (or rightmost node in AVL tree)
+            latest = tree.max();
+            if (!is_static) {
+                // since fragment is a real-time fragment, check if it is in the AVL tree
+                if (created.getTime() >= tree.min() && created.getTime() <= tree.max()) {
+                    const node = tree.find(created.getTime());
+                    members = node.data;
+                    id = node.key;
                 } else {
-                    // fragment cannot be found, so send 404
-                    res.status(404).send();
+                    // if fragment is not in the AVL tree, get it from the directory.
+                    members = JSON.parse(await readFile(`${storage}/feed_history/${agency}/${created.toISOString()}.json`));
+                    id = created.getTime();
+                }
+
+                // get previous page
+                if (index > 0) {
+                    previous = RTData.RTFragments[agency][index - 1];
+                } else {
+                    // if index === 0, then previous is in the static data
+                    const static_versions = Object.keys(staticData.staticFragments[agency]).sort();
+                    previous = static_versions[static_versions.length - 1];
+                }
+
+                // get next page
+                if (index < RTData.RTFragments[agency].length - 1) {
+                    next = RTData.RTFragments[agency][index + 1];
+                }
+
+                // we don't need departure_time with real-time data
+                departure_time = null;
+            } else {
+                // data is static, so get it from the directory (since we don't store static data in the AVL tree).
+                // NOTE: when providing static data, we paginate the LDES by 'created' time (aka the different static
+                // versions) AND by 'departure_time'.
+
+                // first, make sure that we have a valid departure_time
+                if (departure_time.toString() === 'Invalid Date') {
+                    // if we don't have a departure time yet, we take the first departure time in the current
+                    // version of static data
+                    departure_time = new Date(staticData.staticFragments[agency][created.toISOString()][0]);
+                }
+                // now that we have a valid departure time, we look for a matching fragment
+                let [_, static_fragment, static_index] = utils.findResource(agency, departure_time.getTime(), [created], staticData.staticFragments);
+
+                const static_fragment_date = new Date(static_fragment);
+                // Redirect client to the appropriate fragment URL
+                if (departure_time.getTime() !== static_fragment) {
+                    res.location(`/${agency}/connections/feed?created=${created.toISOString()}&departureTime=${static_fragment_date.toISOString()}`);
+                    res.status(302).send();
                     return;
                 }
 
-            }
+                // get fragment data from disk
+                let static_path = storage + '/linked_pages/' + agency + '/' + created.toISOString();
+                members = JSON.parse('[' + await utils.readAndGunzip(`${static_path}/${static_fragment_date.toISOString()}.jsonld.gz`) + ']');
+                id = created.getTime();
 
+                // get previous and next version if possible and necessary
+                if (static_index === 0) {
+                    const static_versions = Object.keys(staticData.staticFragments[agency]).sort();
+                    const version_index = static_versions.indexOf(created.getTime());
 
-
-
-
-
-            // Array that will contain all the Connections of this fragment
-            let jsonldGraph = [];
-            let lowLimit = found_fragment;
-            let highLimit = staticData.staticFragments[agency][static_version][index + 1];
-
-            // Check if the in-memory AVL Tree contains this fragment
-            if (departureTime.getTime() >= connTrees[agency].min && departureTime.getTime() < connTrees[agency].max) {
-                t0 = new Date()
-                const tree = connTrees[agency].avlTree;
-                const node = tree.find(found_fragment);
-                let prev = tree.prev(node);
-                let next = tree.next(node);
-
-                jsonldGraph.push(node.data);
-
-                // Complete connection departing at the same time
-                while (prev && prev.key === lowLimit) {
-                    jsonldGraph.push(prev.data);
-                    prev = tree.prev(prev);
-                }
-
-                // Add all connections until the beginning of the next fragment
-                while (next && next.key < highLimit) {
-                    jsonldGraph.push(next.data);
-                    next = tree.next(next);
-                }
-                logger.debug('Build fragment from AVL Tree took ' + (new Date().getTime() - t0.getTime()) + ' ms');
-
-                // Set cache headers
-                const conf = utils.getCompanyDatasetConfig(agency);
-                if (conf['realTimeData']) {
-                    // Valid until the next update + 1 second to allow intermediate caches to update
-                    const rtUpdatePeriod = conf['realTimeData']['updatePeriod'];
-                    const validUntilDate = utils.getNextUpdate(rtUpdatePeriod);
-                    const maxage = Math.round((validUntilDate - now) / 1000);
-                    res.set({ 'Cache-Control': 'public, s-maxage=' + maxage + ', max-age=' + (maxage + 1)
-                            + ', stale-if-error=' + (maxage + 15) + ', proxy-revalidate' });
-                    res.set({ 'Expires': validUntilDate.toUTCString() });
-                } else {
-                    // Data is static so it can be cached for long time
-                    res.set({ 'Cache-Control': 'public, max-age=31536000000, immutable' });
-                    res.set({ 'Expires': new Date(now.getTime() + 31536000000).toUTCString() });
-                }
-
-            } else {
-                // Build fragment by loading static and live connections (if available) from disk
-                let sf_path = storage + '/linked_pages/' + agency + '/' + static_version + '/';
-                let rt_exists = false;
-
-                // Get all real-time fragments and remove_files needed to cover the requested static fragment
-                t0 = new Date();
-                let [rtfs, rtfs_remove] = utils.findRTData(agency, lowLimit, highLimit);
-                logger.debug('findRTData() took ' + (new Date().getTime() - t0.getTime()) + ' ms');
-
-                if (rtfs.length > 0) {
-                    // There are real-time data fragments available for this request
-                    rt_exists = true;
-                }
-
-                // Check if this is a conditional get request, and if so check if we can close this request with a 304
-                if (rt_exists) {
-                    if (utils.handleConditionalGET(agency, req, res, accept, rtfs[rtfs.length - 1], true, departureTime)) {
-                        return;
+                    // if we are on the first departureTime fragment and there is a previous static version,
+                    // then we set previous
+                    if (version_index > 0) {
+                        previous = static_versions[version_index - 1];
                     }
-                } else {
-                    if (utils.handleConditionalGET(agency, req, res, accept, sf_path, false, departureTime)) {
-                        return;
+
+                    // if we are on the first departureTime fragment and there is a next static or real-time version,
+                    // then we set next
+                    if (version_index < static_versions.length - 1) {
+                        next = static_versions[version_index + 1];
+                    } else if (version_index === static_versions.length - 1) {
+                        next = RTData.RTFragments[agency][0];
                     }
                 }
 
-                // Get respective static data fragment according to departureTime query
-                // and complement resource with Real-Time data and Hydra metadata before sending it back to the client
-                t0 = new Date();
-                let static_buffer = await utils.readAndGunzip(sf_path + ff.toISOString() + '.jsonld.gz');
-                jsonldGraph = static_buffer.split(',\n').map(JSON.parse);
-                logger.debug('Read and process static fragment took ' + (new Date().getTime() - t0.getTime()) + ' ms');
-
-                // Get real time data for this agency and requested time
-                if (rt_exists || rtfs_remove.length > 0) {
-                    let rt_data = [];
-
-                    t0 = new Date();
-                    await Promise.all(rtfs.map(async rt => {
-                        let rt_buffer = [];
-                        if (rt.indexOf('.gz') > 0) {
-                            rt_buffer.push((await utils.readAndGunzip(rt)));
-                        } else {
-                            rt_buffer.push((await readfile(rt, 'utf8')));
-                        }
-                        rt_data.push(rt_buffer.toString().split('\n'));
-                    }));
-                    logger.debug('Load all RT fragments (' + rtfs.length + ') took ' + (new Date().getTime() - t0.getTime()) + ' ms');
-
-                    // Combine static and real-time data
-                    t0 = new Date();
-                    logger.debug('-----------aggregateRTData()-----------');
-                    jsonldGraph = await utils.aggregateRTData(jsonldGraph, rt_data, rtfs_remove, lowLimit, highLimit, now);
-                    logger.debug('---------------------------------------');
-                    logger.debug('aggregateRTData() took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+                // get next departure time fragment if possible
+                const static_fragments = staticData.staticFragments[agency][created];
+                if (static_index < static_fragments.length - 1) {
+                    next_departure = static_fragments[static_index + 1];
                 }
             }
 
             const params = {
                 host: host,
                 agency: agency,
-                departureTime: ff,
-                version: static_version,
-                index: index,
-                data: jsonldGraph,
-                staticFragments: staticData.staticFragments
+                members: members,       // connections
+                id: id,                 // epoch time of created
+                previous: previous,     // epoch time of previous fragment
+                next: next,             // epoch time of next fragment
+                latest: latest,         // epoch time of latest fragment
+                isStatic: is_static,
+                departureTime: departure_time,
+                nextDeparture: next_departure,
             };
 
+            console.log(members.length);
 
+            // create LDES page
+            t0 = new Date();
+            let final_data = await utils.addLDESMetadata(params);
 
-            let final_data = await utils.addHydraMetada(params);
-
-            res.set({ 'Vary': 'Accept, Accept-Encoding, Accept-Datetime' });
+            res.set({'Vary': 'Accept, Accept-Encoding, Accept-Datetime'});
 
             switch (accept) {
                 case 'application/json':
-                    res.set({ 'Content-Type': 'application/ld+json' });
+                    res.set({'Content-Type': 'application/ld+json'});
                     res.status(200).send(final_data);
                     break;
                 case 'application/ld+json':
-                    res.set({ 'Content-Type': 'application/ld+json' });
+                    res.set({'Content-Type': 'application/ld+json'});
                     res.status(200).send(final_data);
                     break;
                 case 'text/turtle':
-                    res.set({ 'Content-Type': 'application/trig' });
+                    res.set({'Content-Type': 'application/trig'});
                     res.status(200).send(await utils.jsonld2RDF(final_data, 'text/turtle'));
                     break;
                 case 'application/n-triples':
-                    res.set({ 'Content-Type': 'application/n-quads' });
+                    res.set({'Content-Type': 'application/n-quads'});
                     res.status(200).send(await utils.jsonld2RDF(final_data, 'application/n-triples'));
                     break;
                 case 'application/n-quads':
-                    res.set({ 'Content-Type': 'application/n-quads' });
+                    res.set({'Content-Type': 'application/n-quads'});
                     res.status(200).send(await utils.jsonld2RDF(final_data, 'application/n-quads'));
                     break;
                 case 'application/trig':
-                    res.set({ 'Content-Type': 'application/trig' });
+                    res.set({'Content-Type': 'application/trig'});
                     res.status(200).send(await utils.jsonld2RDF(final_data, 'application/trig'));
                     break;
                 default:
-                    res.set({ 'Content-Type': 'application/ld+json' });
+                    res.set({'Content-Type': 'application/ld+json'});
+                    console.log(final_data);
                     res.status(200).send(final_data);
                     break;
             }
 
-            t0 = new Date();
             logger.debug('Add Metadata took ' + (new Date().getTime() - t0.getTime()) + ' ms');
 
         } catch (err) {
             if (err) {
                 logger.error(err);
                 console.error(err);
-            };
-            res.set({ 'Cache-Control': 'no-cache' });
+            }
+            res.set({'Cache-Control': 'no-cache'});
             res.status(404).send();
         }
-
-    }
-
-    createFeed(company) {
 
     }
 
@@ -340,3 +280,5 @@ class Feed {
         return this._datasets
     }
 }
+
+module.exports = Feed;

--- a/lib/routes/feed.js
+++ b/lib/routes/feed.js
@@ -102,7 +102,6 @@ class Feed {
             logger.debug('finding fragment took ' + (new Date().getTime() - t0.getTime()) + ' ms');
 
             // Redirect client to the appropriate fragment URL
-            console.log("times:", created.getTime(), found_fragment);
             if (created.getTime() !== found_fragment) {
                 let found_fragment_date = new Date(found_fragment);
                 res.location('/' + agency + '/connections/feed?created=' + found_fragment_date.toISOString());
@@ -154,9 +153,12 @@ class Feed {
                     // if we don't have a departure time yet, we take the first departure time in the current
                     // version of static data
                     departure_time = new Date(staticData.staticFragments[agency][created.toISOString()][0]);
+                    res.location(`/${agency}/connections/feed?created=${created.toISOString()}&departureTime=${departure_time.toISOString()}`);
+                    res.status(302).send();
+                    return;
                 }
                 // now that we have a valid departure time, we look for a matching fragment
-                let [_, static_fragment, static_index] = utils.findResource(agency, departure_time.getTime(), [created], staticData.staticFragments);
+                let [_, static_fragment, static_index] = utils.findResource(agency, departure_time.getTime(), [created.toISOString()], staticData.staticFragments);
 
                 const static_fragment_date = new Date(static_fragment);
                 // Redirect client to the appropriate fragment URL
@@ -174,7 +176,7 @@ class Feed {
                 // get previous and next version if possible and necessary
                 if (static_index === 0) {
                     const static_versions = Object.keys(staticData.staticFragments[agency]).sort();
-                    const version_index = static_versions.indexOf(created.getTime());
+                    const version_index = static_versions.indexOf(created.toISOString());
 
                     // if we are on the first departureTime fragment and there is a previous static version,
                     // then we set previous
@@ -192,11 +194,19 @@ class Feed {
                 }
 
                 // get next departure time fragment if possible
-                const static_fragments = staticData.staticFragments[agency][created];
+                const static_fragments = staticData.staticFragments[agency][created.toISOString()];
                 if (static_index < static_fragments.length - 1) {
                     next_departure = static_fragments[static_index + 1];
                 }
             }
+
+            members.forEach( (member, index) => {
+                member["dcterms:isVersionOf"] = member["@id"];
+                member["@id"] += `/${created.toISOString()}`;
+                member["created"] = created.toISOString();
+            });
+
+            departure_time = (departure_time !== null) ? departure_time.getTime() : null;
 
             const params = {
                 host: host,
@@ -211,7 +221,7 @@ class Feed {
                 nextDeparture: next_departure,
             };
 
-            console.log(members.length);
+            console.log(next);
 
             // create LDES page
             t0 = new Date();
@@ -246,7 +256,6 @@ class Feed {
                     break;
                 default:
                     res.set({'Content-Type': 'application/ld+json'});
-                    console.log(final_data);
                     res.status(200).send(final_data);
                     break;
             }

--- a/lib/routes/feed.js
+++ b/lib/routes/feed.js
@@ -1,0 +1,39 @@
+const util = require('util');
+const fs = require('fs');
+const utils = require('../utils/utils');
+
+const readFile = util.promisify(fs.readFile);
+const readdir = util.promisify(fs.readdir);
+const writeFile = util.promisify(fs.writeFile);
+
+class Feed{
+    constructor() {
+        this._storage = utils.datasetsConfig.storage;
+        this._datasets = utils.datasetsConfig.datasets;
+        this._serverConfig = utils.serverConfig;
+    }
+
+    async getFeed(req, res) {
+
+    }
+
+    createFeed(company) {
+
+    }
+
+    getDataset(name) {
+        for (let i in this.datasets) {
+            if (this.datasets[i].companyName === name) {
+                return this.datasets[i];
+            }
+        }
+    }
+
+    get storage(){
+        return this._storage;
+    }
+
+    get datasets(){
+        return this._datasets
+    }
+}

--- a/lib/routes/feed.js
+++ b/lib/routes/feed.js
@@ -188,7 +188,7 @@ class Feed {
                     // then we set next
                     if (version_index < static_versions.length - 1) {
                         next = static_versions[version_index + 1];
-                    } else if (version_index === static_versions.length - 1) {
+                    } else if (version_index === static_versions.length - 1 && RTData.RTFragments[agency].length > 0) {
                         next = RTData.RTFragments[agency][0];
                     }
                 }

--- a/lib/routes/page-finder.js
+++ b/lib/routes/page-finder.js
@@ -36,6 +36,9 @@ class PageFinder {
     }
 
     async getConnections(req, res) {
+        /**
+         * PREPARE RESPONSE AND REDIRECT USER TO A VALID URL IF NECESSARY
+         */
         let t0 = new Date();
         // Check for available updates of the static fragments
         await staticData.updateStaticFragments();
@@ -64,6 +67,8 @@ class PageFinder {
         const agency = req.params.agency;
         let departureTime = new Date(decodeURIComponent(req.query.departureTime));
         let version = new Date(decodeURIComponent(req.query.version));
+
+        console.log("version:", req.query.version);
 
         // WARNING: storage should not end on a /
         // TODO: use path to avoid OS compatibility issues and handle the trailing slash
@@ -107,7 +112,7 @@ class PageFinder {
                 let sortedVersions = utils.sortVersions(acceptDatetime, versions);
                 // Find closest resource to requested version 
                 let closest_version = utils.findResource(agency, departureTime.getTime(), sortedVersions, staticData.staticFragments);
-                // Set Memento headers pointng to the found version
+                // Set Memento headers pointing to the found version
                 res.location('/' + agency + '/connections/memento?version=' + closest_version[0] + '&departureTime=' + new Date(closest_version[1]).toISOString());
                 res.set({
                     'Vary': 'Accept, Accept-Encoding, Accept-Datetime',
@@ -135,6 +140,9 @@ class PageFinder {
                 return;
             }
 
+            /**
+             * START CREATING PAGES USING AVL TREE AND STATIC DATA FROM DISK
+             */
             // Array that will contain all the Connections of this fragment
             let jsonldGraph = [];
             let lowLimit = found_fragment;

--- a/lib/routes/page-finder.js
+++ b/lib/routes/page-finder.js
@@ -36,9 +36,6 @@ class PageFinder {
     }
 
     async getConnections(req, res) {
-        /**
-         * PREPARE RESPONSE AND REDIRECT USER TO A VALID URL IF NECESSARY
-         */
         let t0 = new Date();
         // Check for available updates of the static fragments
         await staticData.updateStaticFragments();
@@ -67,8 +64,6 @@ class PageFinder {
         const agency = req.params.agency;
         let departureTime = new Date(decodeURIComponent(req.query.departureTime));
         let version = new Date(decodeURIComponent(req.query.version));
-
-        console.log("version:", req.query.version);
 
         // WARNING: storage should not end on a /
         // TODO: use path to avoid OS compatibility issues and handle the trailing slash
@@ -112,7 +107,7 @@ class PageFinder {
                 let sortedVersions = utils.sortVersions(acceptDatetime, versions);
                 // Find closest resource to requested version 
                 let closest_version = utils.findResource(agency, departureTime.getTime(), sortedVersions, staticData.staticFragments);
-                // Set Memento headers pointing to the found version
+                // Set Memento headers pointng to the found version
                 res.location('/' + agency + '/connections/memento?version=' + closest_version[0] + '&departureTime=' + new Date(closest_version[1]).toISOString());
                 res.set({
                     'Vary': 'Accept, Accept-Encoding, Accept-Datetime',
@@ -140,9 +135,6 @@ class PageFinder {
                 return;
             }
 
-            /**
-             * START CREATING PAGES USING AVL TREE AND STATIC DATA FROM DISK
-             */
             // Array that will contain all the Connections of this fragment
             let jsonldGraph = [];
             let lowLimit = found_fragment;

--- a/lib/routes/page-finder.js
+++ b/lib/routes/page-finder.js
@@ -27,7 +27,7 @@ class PageFinder {
     async init() {
         // Create static fragments index structure
         await staticData.updateStaticFragments();
-        // Get 50 fragments from now into a AVL tree
+        // Create an AVL tree-based index of Connections for every data source
         for (const d of utils.datasetsConfig['datasets']) {
             const tree = new Connections({ staticData: staticData, agency: d['companyName'] });
             await tree.init();
@@ -59,8 +59,20 @@ class PageFinder {
         }
 
         const host = protocol + '://' + server_config.hostname + '/';
+
+        // Request path and query parameters
         const agency = req.params.agency;
         let departureTime = new Date(decodeURIComponent(req.query.departureTime));
+        let version = new Date(decodeURIComponent(req.query.version));
+
+        // WARNING: storage should not end on a /
+        // TODO: use path to avoid OS compatibility issues and handle the trailing slash
+        // Check if there is data for the requested company
+        if (!fs.existsSync(storage + '/linked_pages/' + agency)) {
+            res.set({ 'Cache-Control': 'no-cache' });
+            res.status(404).send("Agency not found");
+            return;
+        }
 
         // Accept header
         const accept = accepts(req).type(mimeTypes);
@@ -73,16 +85,8 @@ class PageFinder {
 
         // Redirect to proper URL if final / is given before params
         if (req.url.indexOf('connections/') >= 0) {
-            res.location('/' + agency + '/connections?departureTime=' + departureTime.toISOString());
+            res.location(`/${agency}/connections?departureTime=${departureTime.toISOString()}&version=${version.toISOString()}`);
             res.status(302).send();
-            return;
-        }
-
-        // WARNING: storage should not end on a /
-        // Check if there is data for the requested company
-        if (!fs.existsSync(storage + '/linked_pages/' + agency)) {
-            res.set({ 'Cache-Control': 'no-cache' });
-            res.status(404).send("Agency not found");
             return;
         }
 

--- a/lib/routes/router.js
+++ b/lib/routes/router.js
@@ -5,6 +5,8 @@ const Catalog = require('./catalog');
 const Stops = require('./stops');
 const Routes = require('./routes');
 const Feed = require('./feed');
+const fs = require('fs');
+const utils = require('../utils/utils')
 
 const router = express.Router();
 const pageFinder = new PageFinder();
@@ -31,6 +33,20 @@ memento.init().then(() => {
 feed.init().then(() => {
     router.get('/:agency/connections/feed', (req, res) => {
         feed.getFeed(req, res);
+    });
+    router.get('/:agency/connections/feed/shape', async (req, res) => {
+        let host = req.headers.host;
+
+        console.log("host:", host);
+        console.log("originalUrl:", req.originalUrl);
+
+        let shape = await utils.addSHACLMetadata({
+            "id": req.protocol + '://' + host + req.originalUrl,
+            "ldes": req.protocol + '://' + host + req.originalUrl.substring(0, req.originalUrl.indexOf("shape"))
+        });
+
+        res.set({'Content-Type': 'application/ld+json'});
+        res.status(200).send(shape);
     });
 });
 

--- a/lib/routes/router.js
+++ b/lib/routes/router.js
@@ -4,6 +4,7 @@ const Memento = require('./memento');
 const Catalog = require('./catalog');
 const Stops = require('./stops');
 const Routes = require('./routes');
+// const Feed = require('./feed');
 
 const router = express.Router();
 const pageFinder = new PageFinder();
@@ -11,6 +12,7 @@ const memento = new Memento();
 const catalog = new Catalog();
 const stops = new Stops();
 const routes = new Routes();
+// const feed = new Feed();
 
 // Define HTTP routes only after required data has been initialized
 pageFinder.init().then(() => {
@@ -24,6 +26,10 @@ memento.init().then(() => {
         memento.getMemento(req, res);
     });
 });
+
+// router.get('/:agency/connections/feed', ((req, res) => {
+//         feed.getFeed(req, res);
+// }));
 
 router.get('/:agency/catalog', (req, res) => {
     catalog.getCatalog(req, res);

--- a/lib/routes/router.js
+++ b/lib/routes/router.js
@@ -4,7 +4,7 @@ const Memento = require('./memento');
 const Catalog = require('./catalog');
 const Stops = require('./stops');
 const Routes = require('./routes');
-// const Feed = require('./feed');
+const Feed = require('./feed');
 
 const router = express.Router();
 const pageFinder = new PageFinder();
@@ -12,7 +12,7 @@ const memento = new Memento();
 const catalog = new Catalog();
 const stops = new Stops();
 const routes = new Routes();
-// const feed = new Feed();
+const feed = new Feed();
 
 // Define HTTP routes only after required data has been initialized
 pageFinder.init().then(() => {
@@ -27,9 +27,12 @@ memento.init().then(() => {
     });
 });
 
-// router.get('/:agency/connections/feed', ((req, res) => {
-//         feed.getFeed(req, res);
-// }));
+
+feed.init().then(() => {
+    router.get('/:agency/connections/feed', (req, res) => {
+        feed.getFeed(req, res);
+    });
+});
 
 router.get('/:agency/catalog', (req, res) => {
     catalog.getCatalog(req, res);

--- a/lib/utils/avl-tree.js
+++ b/lib/utils/avl-tree.js
@@ -469,7 +469,7 @@ class AVLTree {
 
     /**
      * Insert a node into the tree
-     * @param  {Key} key
+     * @param  {number} key
      * @param  {Value} [data]
      * @return {?Node}
      */

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -7,8 +7,8 @@ const jsonld = require('jsonld');
 const Logger = require('./logger');
 const cronParser = require('cron-parser');
 const N3 = require('n3');
-const { DataFactory } = N3;
-const { namedNode, literal, blankNode, defaultGraph, quad } = DataFactory;
+const {DataFactory} = N3;
+const {namedNode, literal, blankNode, defaultGraph, quad} = DataFactory;
 
 const readFile = util.promisify(fs.readFile);
 const readdir = util.promisify(fs.readdir);
@@ -53,7 +53,7 @@ module.exports = new class Utils {
                 path += '.zip';
             }
             fs.createReadStream(path)
-                .pipe(unzip.Extract({ path: dirName }))
+                .pipe(unzip.Extract({path: dirName}))
                 .on('close', () => {
                     resolve(dirName);
                 })
@@ -70,7 +70,7 @@ module.exports = new class Utils {
 
         for (let v of versions) {
             let diff = Math.abs(date.getTime() - new Date(v).getTime());
-            diffs.push({ 'version': v, 'diff': diff });
+            diffs.push({'version': v, 'diff': diff});
         }
 
         diffs.sort((a, b) => {
@@ -84,18 +84,29 @@ module.exports = new class Utils {
         return sorted;
     }
 
+    /**
+     * find the closest real-time fragment to the left of a given target date.
+     *
+     * @param agency
+     * @param target
+     * @param RTFragments
+     * @returns {null}
+     */
     findRTResource(agency, target, RTFragments) {
         let fragment = null;
         let fragments = RTFragments[agency];
 
-        if (target >= fragments[0] && target <= fragments[fragments.length - 1]) {
+        if (target >= fragments[0]) {
             fragment = this.binarySearch(target, fragments);
+            if (fragment === null) {
+                // if fragment is null after binary search, then just refer to the latest fragment
+                fragment = [fragments[fragments.length - 1], fragments.length - 1]
+            }
         }
-        if (fragment !== null){
+        if (fragment !== null) {
             return fragment;
-        }
-        else {
-            return null;
+        } else {
+            throw new Error('Fragment not found in current data');
         }
     }
 
@@ -121,6 +132,47 @@ module.exports = new class Utils {
             return version.concat(fragment);
         } else {
             throw new Error('Fragment not found in current data');
+        }
+    }
+
+    /**
+     * Find the fragment that has the closest creation date to the left of a given target date.
+     * We first look in the real-time fragments, then we look in the staticFragments (if necessary).
+     *
+     * @param agency the company for which we are finding a fragment
+     * @param target the target date. We look for the fragment with the closest creation date to the
+     *               left of this target date.
+     * @param RTFragments index for real-time data fragments
+     * @param staticFragments index for static data fragments
+     */
+    findFeedResource(agency, target, RTFragments, staticFragments) {
+        let is_static;
+        let rt_min = RTFragments[agency][0];
+        // let rt_max = RTFragments[agency][RTFragments[agency].length - 1];
+
+        try {
+            // first, check if the fragment can be found in the real-time fragments
+            if (target >= rt_min) {
+                // if target date is in range of real-time data, get the closest fragment to the left of it
+                let result = this.findRTResource(agency, target, RTFragments);
+                is_static = false;
+                return [result[0], result[1], is_static]
+            }
+
+            // the fragment wasn't found in the real-time data, so now we look in the static data
+            let versions = Object.keys(staticFragments[agency]).sort().map(ver => new Date(ver).getTime());
+            let result = this.binarySearch(target, versions);
+            if (result !== null) {
+                // if target date is in range of static data, get the closest fragment to the left of it
+                is_static = true;
+                return [result[0], result[1], is_static]
+            } else {
+                is_static = true;
+                return [versions[versions.length - 1], versions.length - 1, is_static]
+            }
+        } catch (err) {
+            // if an exception occurred, throw it again so we can handle it
+            throw err;
         }
     }
 
@@ -423,7 +475,7 @@ module.exports = new class Utils {
 
     async addHydraMetada(params) {
         try {
-            let template = await readFile('./statics/skeleton.jsonld', { encoding: 'utf8' });
+            let template = await readFile('./statics/skeleton.jsonld', {encoding: 'utf8'});
             let jsonld_skeleton = JSON.parse(template);
             let host = params.host;
             let agency = params.agency;
@@ -464,20 +516,58 @@ module.exports = new class Utils {
             let ldes = JSON.parse(template);
             let host = params.host;
             let agency = params.agency;
-            let shaclFile = params.shape;
-            let members = params.members;
-            let id = params.id;
+            let members = params.members; // connections
+            let id = new Date(params.id); // epoch time of created
+            let next = new Date(params.next); // epoch time of next fragment
+            let previous = new Date(params.previous); // epoch time of previous fragment
+            let latest = new Date(params.latest); // epoch time of latest fragment
+            let is_static = params.isStatic; // bool that will tell you if data fragment is static
+
+            await this.addSHACLMetadata({
+                "id": host + agency + '/connections/feed/shape',
+                "ldes": host + agency + '/connections/feed/'
+            });
+
+            let departureTime = "";
+            let nextDeparture = "";
+            if (is_static) {
+                departureTime = params.departureTime ? params.departureTime : "";
+                nextDeparture = params.nextDeparture ? params.nextDeparture : "";
+            }
+
+            let dt = (departureTime === "") ? "" : "?departureTime=" + departureTime;
+            let ndt = (nextDeparture === "") ? "" : "?departureTime=" + nextDeparture;
 
             ldes['@id'] = host + agency + '/connections/feed';
-            ldes['tree:shape'] = shaclFile;
+            ldes['tree:shape'] = host + agency + '/connections/feed/shape';
             ldes['member'] = [];
             for (const member of members) {
                 ldes['member'].push(member);
-            }
-            ldes['tree:view']['@id'] = host + agency + `/connections/feed?created=${id}`;
-            ldes['tree:view']['tree:relation'] = []
-            // TODO create the tree:relation s
 
+            }
+
+            ldes['tree:view']['@id'] = host + agency + `/connections/feed?created=${id.toISOString()}` + dt;
+
+            let treeRelations = [];
+            treeRelations.push({
+                "@type": "tree:GreaterThanRelation",
+                "tree:node": host + agency + `/connections/feed?created=${next.toISOString()}` + ndt,
+                "tree:value": {
+                    "@value": `${next.toISOString()}`,
+                    "@type": "xsd:dateTime"
+                },
+                "tree:path": "dcterms:created"
+            });
+            treeRelations.push({
+                "@type": "tree:LessThanRelation",
+                "tree:node": host + agency + `/connections/feed?created=${previous.toISOString()}`,
+                "tree:value": {
+                    "@value": `${next.toISOString()}`,
+                    "@type": "xsd:dateTime"
+                },
+                "tree:path": "dcterms:created"
+            });
+            ldes['tree:view']['tree:relation'] = treeRelations;
 
             return ldes;
         } catch (err) {
@@ -486,17 +576,35 @@ module.exports = new class Utils {
         }
     }
 
+    async addSHACLMetadata(params) {
+        try {
+            let template = await readFile('./statics/shape.json', {encoding: 'utf8'});
+            let shape = JSON.parse(template);
+
+            let id = params.id;
+            let ldes = params.ldes;
+
+            shape['@id'] = id;
+            shape['shapeOf'] = ldes;
+
+            return shape;
+        } catch (err) {
+            console.error(err);
+            throw err;
+        }
+    }
+
     /**
-    * Checks for Conditional GET requests, by comparing the last modified date and file hash 
-    * against if-modified-since and if-none-match headers.
-    * If a match is made, a 304 response is sent and the function will return true.
-    * If the client needs a new version (i.e. a body should be sent), the function will return false
-    * @param req
-    * @param res
-    * @param filepath The path of the file which would be used to generate the response
-    * @param departureTime The time for which this document was requested
-    * @returns boolean True if a 304 response is to be served
-    */
+     * Checks for Conditional GET requests, by comparing the last modified date and file hash
+     * against if-modified-since and if-none-match headers.
+     * If a match is made, a 304 response is sent and the function will return true.
+     * If the client needs a new version (i.e. a body should be sent), the function will return false
+     * @param req
+     * @param res
+     * @param filepath The path of the file which would be used to generate the response
+     * @param departureTime The time for which this document was requested
+     * @returns boolean True if a 304 response is to be served
+     */
     handleConditionalGET(company, req, res, accept, filepath, hasLiveData, departureTime, memento) {
         let ifModifiedSinceRawHeader = req.header('if-modified-since');
         let ifModifiedSinceHeader = undefined;
@@ -544,18 +652,18 @@ module.exports = new class Utils {
         if ((memento && memento < now) || departureTime < (now - 10800000)) {
             // Immutable (for browsers which support it, sometimes limited to https only
             // 1 year expiry date to keep it long enough in cache for the others
-            res.set({ 'Cache-Control': 'public, max-age=31536000000, immutable' });
-            res.set({ 'Expires': new Date(now.getTime() + 31536000000).toUTCString() });
+            res.set({'Cache-Control': 'public, max-age=31536000000, immutable'});
+            res.set({'Expires': new Date(now.getTime() + 31536000000).toUTCString()});
         } else {
             // Let clients hold on to this data for 1 second longer than nginx. This way nginx can update before the clients
-            res.set({ 'Cache-Control': 'public, s-maxage=' + maxage + ', max-age=' + (maxage + 1) + ', stale-if-error=' + (maxage + 15) + ', proxy-revalidate' });
-            res.set({ 'Expires': validUntilDate.toUTCString() });
+            res.set({'Cache-Control': 'public, s-maxage=' + maxage + ', max-age=' + (maxage + 1) + ', stale-if-error=' + (maxage + 15) + ', proxy-revalidate'});
+            res.set({'Expires': validUntilDate.toUTCString()});
         }
 
-        res.set({ 'ETag': etag });
-        res.set({ 'Vary': 'Accept-Encoding, Accept-Datetime' });
-        res.set({ 'Last-Modified': lastModifiedDate.toUTCString() });
-        res.set({ 'Content-Type': 'application/ld+json' });
+        res.set({'ETag': etag});
+        res.set({'Vary': 'Accept-Encoding, Accept-Datetime'});
+        res.set({'Last-Modified': lastModifiedDate.toUTCString()});
+        res.set({'Content-Type': 'application/ld+json'});
 
         // If an if-none-match header exists, and if the real-time data hasn't been updated since, just return a 304
         // According to the spec this header takes priority over if-modified-since 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -84,6 +84,21 @@ module.exports = new class Utils {
         return sorted;
     }
 
+    findRTResource(agency, target, RTFragments) {
+        let fragment = null;
+        let fragments = RTFragments[agency];
+
+        if (target >= fragments[0] && target <= fragments[fragments.length - 1]) {
+            fragment = this.binarySearch(target, fragments);
+        }
+        if (fragment !== null){
+            return fragment;
+        }
+        else {
+            return null;
+        }
+    }
+
     // Search for a given fragment across the different static versions
     findResource(agency, target, versions, staticFragments) {
         let version = null;
@@ -443,6 +458,34 @@ module.exports = new class Utils {
         }
     }
 
+    async addLDESMetadata(params) {
+        try {
+            let template = await readFile('./statics/skeleton-ldes.jsonld', {encoding: 'utf8'});
+            let ldes = JSON.parse(template);
+            let host = params.host;
+            let agency = params.agency;
+            let shaclFile = params.shape;
+            let members = params.members;
+            let id = params.id;
+
+            ldes['@id'] = host + agency + '/connections/feed';
+            ldes['tree:shape'] = shaclFile;
+            ldes['member'] = [];
+            for (const member of members) {
+                ldes['member'].push(member);
+            }
+            ldes['tree:view']['@id'] = host + agency + `/connections/feed?created=${id}`;
+            ldes['tree:view']['tree:relation'] = []
+            // TODO create the tree:relation s
+
+
+            return ldes;
+        } catch (err) {
+            console.error(err);
+            throw err;
+        }
+    }
+
     /**
     * Checks for Conditional GET requests, by comparing the last modified date and file hash 
     * against if-modified-since and if-none-match headers.
@@ -669,6 +712,14 @@ module.exports = new class Utils {
 
         return value;
     }
+
+    // parseCronExp(cronExp){
+    //     let sec = 0;
+    //     const arr = cronExp.split(" ");
+    //     for (let i = 0; i < arr.length; i++) {
+    //
+    //     }
+    // }
 
     get datasetsConfig() {
         return this._datasetsConfig;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -585,9 +585,9 @@ module.exports = new class Utils {
                 });
             }
             // latest created
-            if (latest !== null) {
+            if (latest !== null && (latest !== id)) {
                 treeRelations.push({
-                    "@type": "tree:GreaterThanOrEqualRelation",
+                    "@type": "tree:GreaterThanRelation",
                     "tree:node": host + agency + `/connections/feed?created=${latest.toISOString()}`,
                     "tree:value": {
                         "@value": `${id.toISOString()}`,

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -518,9 +518,9 @@ module.exports = new class Utils {
             let agency = params.agency;
             let members = params.members; // connections
             let id = new Date(params.id); // epoch time of created
-            let next = new Date(params.next); // epoch time of next fragment
-            let previous = new Date(params.previous); // epoch time of previous fragment
-            let latest = new Date(params.latest); // epoch time of latest fragment
+            let next = (params.next !== null) ? new Date(params.next) : null; // epoch time of next fragment
+            let previous = (params.previous !== null) ? new Date(params.previous) : null; // epoch time of previous fragment
+            let latest = (params.latest !== null) ? new Date(params.latest) : null; // epoch time of latest fragment
             let is_static = params.isStatic; // bool that will tell you if data fragment is static
 
             await this.addSHACLMetadata({
@@ -528,45 +528,74 @@ module.exports = new class Utils {
                 "ldes": host + agency + '/connections/feed/'
             });
 
-            let departureTime = "";
-            let nextDeparture = "";
-            if (is_static) {
-                departureTime = params.departureTime ? params.departureTime : "";
-                nextDeparture = params.nextDeparture ? params.nextDeparture : "";
-            }
+            let departureTime = (params.departureTime !== null) ? new Date(params.departureTime) : null;
+            let nextDeparture = (params.nextDeparture !== null) ? new Date(params.nextDeparture) : null;
+            let dt = "";
+            let ndt = "";
 
-            let dt = (departureTime === "") ? "" : "?departureTime=" + departureTime;
-            let ndt = (nextDeparture === "") ? "" : "?departureTime=" + nextDeparture;
+            if (is_static) {
+                dt = (departureTime !== null) ? "&departureTime=" + departureTime.toISOString() : "";
+                ndt = (nextDeparture !== null) ? "&departureTime=" + nextDeparture.toISOString() : "";
+            }
 
             ldes['@id'] = host + agency + '/connections/feed';
             ldes['tree:shape'] = host + agency + '/connections/feed/shape';
             ldes['member'] = [];
             for (const member of members) {
                 ldes['member'].push(member);
-
             }
 
             ldes['tree:view']['@id'] = host + agency + `/connections/feed?created=${id.toISOString()}` + dt;
 
             let treeRelations = [];
-            treeRelations.push({
-                "@type": "tree:GreaterThanRelation",
-                "tree:node": host + agency + `/connections/feed?created=${next.toISOString()}` + ndt,
-                "tree:value": {
-                    "@value": `${next.toISOString()}`,
-                    "@type": "xsd:dateTime"
-                },
-                "tree:path": "dcterms:created"
-            });
-            treeRelations.push({
-                "@type": "tree:LessThanRelation",
-                "tree:node": host + agency + `/connections/feed?created=${previous.toISOString()}`,
-                "tree:value": {
-                    "@value": `${next.toISOString()}`,
-                    "@type": "xsd:dateTime"
-                },
-                "tree:path": "dcterms:created"
-            });
+            // next departure time
+            if (is_static && (nextDeparture !== null)) {
+                treeRelations.push({
+                    "@type": "tree:GreaterThanRelation",
+                    "tree:node": host + agency + `/connections/feed?created=${id.toISOString()}` + ndt,
+                    "tree:value": {
+                        "@value": `${departureTime.toISOString()}`,
+                        "@type": "xsd:dateTime"
+                    },
+                    "tree:path": "departureTime"
+                });
+            }
+            // next created
+            if (next !== null) {
+                treeRelations.push({
+                    "@type": "tree:GreaterThanRelation",
+                    "tree:node": host + agency + `/connections/feed?created=${next.toISOString()}`,
+                    "tree:value": {
+                        "@value": `${id.toISOString()}`,
+                        "@type": "xsd:dateTime"
+                    },
+                    "tree:path": "created"
+                });
+            }
+            // previous created
+            if (previous !== null) {
+                treeRelations.push({
+                    "@type": "tree:LessThanRelation",
+                    "tree:node": host + agency + `/connections/feed?created=${previous.toISOString()}`,
+                    "tree:value": {
+                        "@value": `${id.toISOString()}`,
+                        "@type": "xsd:dateTime"
+                    },
+                    "tree:path": "created"
+                });
+            }
+            // latest created
+            if (latest !== null) {
+                treeRelations.push({
+                    "@type": "tree:GreaterThanOrEqualRelation",
+                    "tree:node": host + agency + `/connections/feed?created=${latest.toISOString()}`,
+                    "tree:value": {
+                        "@value": `${id.toISOString()}`,
+                        "@type": "xsd:dateTime"
+                    },
+                    "tree:path": "created"
+                });
+            }
             ldes['tree:view']['tree:relation'] = treeRelations;
 
             return ldes;

--- a/statics/shape.json
+++ b/statics/shape.json
@@ -1,0 +1,110 @@
+{
+  "@context": {
+    "sh": "https://www.w3.org/ns/shacl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "tree": "https://w3id.org/tree#",
+    "ldes": "https://w3id.org/ldes#",
+    "lc": "http://semweb.mmlab.be/ns/linkedconnections#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dct": "http://purl.org/dc/terms/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "shapeOf": {
+      "@reverse": "tree:shape",
+      "@type": "@id"
+    },
+    "NodeShape": "sh:NodeShape",
+    "sh:nodeKind": {
+      "@type": "@id"
+    },
+    "sh:path": {
+      "@type": "@id"
+    },
+    "sh:datatype": {
+      "@type": "@id"
+    },
+    "sh:class": {
+      "@type": "@id"
+    },
+    "departureTime": {
+      "@id": "lc:departureTime",
+      "@type": "xsd:dateTime"
+    },
+    "member": {
+      "@id": "tree:member",
+      "@type": "@id"
+    },
+    "view": {
+      "@type": "@id",
+      "@id": "tree:view"
+    }
+  },
+  "@id": "",
+  "@type": "ldes:EventStream",
+  "shapeOf": "",
+  "sh:property": [
+    {
+      "sh:path": "dct:isVersionOf",
+      "sh:nodeKind": "sh:IRI",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "dct:created",
+      "sh:nodeKind": "xsd:dateTime",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "lc:departureTime",
+      "sh:nodeKind": "xsd:dateTime",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "lc:departureStop",
+      "sh:nodeKind": "gtfs:Stop",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "lc:departureDelay",
+      "sh:nodeKind": "xsd:duration",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "lc:arrivalTime",
+      "sh:nodeKind": "xsd:dateTime",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "lc:arrivalStop",
+      "sh:nodeKind": "gtfs:Stop",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "lc:arrivalDelay",
+      "sh:nodeKind": "xsd:duration",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "gtfs:trip",
+      "sh:nodeKind": "rdfs:Class",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "gtfs:pickupType",
+      "sh:nodeKind": "rdf:Property",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "gtfs:dropOffType",
+      "sh:nodeKind": "rdf:Property",
+      "sh:maxCount": "1"
+    }
+  ]
+}

--- a/statics/shape.json
+++ b/statics/shape.json
@@ -8,6 +8,7 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "dct": "http://purl.org/dc/terms/",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "gtfs": "http://vocab.gtfs.org/terms#",
     "shapeOf": {
       "@reverse": "tree:shape",
       "@type": "@id"
@@ -29,6 +30,13 @@
       "@id": "lc:departureTime",
       "@type": "xsd:dateTime"
     },
+    "created": {
+      "@id": "dcterms:created",
+      "@type": "xsd:dateTime"
+    },
+    "dcterms:isVersionOf": {
+      "@type": "@id"
+    },
     "member": {
       "@id": "tree:member",
       "@type": "@id"
@@ -36,10 +44,28 @@
     "view": {
       "@type": "@id",
       "@id": "tree:view"
+    },
+    "gtfs:trip": {
+      "@type": "@id"
+    },
+    "gtfs:route": {
+      "@type": "@id"
+    },
+    "gtfs:pickupType": {
+      "@type": "@id"
+    },
+    "gtfs:dropOffType": {
+      "@type": "@id"
+    },
+    "gtfs:Regular": {
+      "@type": "@id"
+    },
+    "gtfs:NotAvailable": {
+      "@type": "@id"
     }
   },
   "@id": "",
-  "@type": "ldes:EventStream",
+  "@type": "NodeShape",
   "shapeOf": "",
   "sh:property": [
     {

--- a/statics/skeleton-ldes.jsonld
+++ b/statics/skeleton-ldes.jsonld
@@ -1,71 +1,70 @@
 {
   "@context": {
-    "tree":"https://w3id.org/tree#",
-    "ldes":"https://w3id.org/ldes#",
+    "tree": "https://w3id.org/tree#",
+    "ldes": "https://w3id.org/ldes#",
     "lc": "http://semweb.mmlab.be/ns/linkedconnections#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "dcterms" : "http://purl.org/dc/terms/",
+    "dcterms": "http://purl.org/dc/terms/",
     "departureTime": {
       "@id": "lc:departureTime",
       "@type": "xsd:dateTime"
     },
-    "member" :  {
-        "@id": "tree:member",
-        "@type": "@id"
+    "member": {
+      "@id": "tree:member",
+      "@type": "@id"
     },
     "view": {
-      "@type":"@id",
-      "@id":"tree:view"
+      "@type": "@id",
+      "@id": "tree:view"
     }
   },
   "@id": "https://{hostname}/{agency}/connections/feed",
   "@type": "ldes:EventStream",
-  "tree:shape" : "{...}/connectionVersionShape.ttl",
+  "tree:shape": "{...}/connectionVersionShape.ttl",
   "member": [
+    {
+      "@id": "https://{hostname}/{agency}/connections/{connectionid}/{version}",
+      "@type": "lc:Connection",
+      "dcterms:isVersionOf": "https://{hostname}/{agency}/connections/{connectionid}",
+      "dcterms:created": "2021-08-01T20:20:000Z",
+      "lc:departureDelay": "...",
+      "gtfs:trip": "...",
+      "lc:arrivalTime": "...",
+      "lc:departureTime": "...",
+      "lc:arrivalStop": "...",
+      "lc:departureStop": "..."
+    }
+  ],
+  "tree:view": {
+    "@id": "{current_page_id}",
+    "tree:relation": [
       {
-         "@id": "https://{hostname}/{agency}/connections/{connectionid}/{version}",
-         "dcterms:isVersionOf": "https://{hostname}/{agency}/connections/{connectionid}",
-         "dcterms:created": "2021-08-01T20:20:000Z",
-         "@type": "lc:Connection",
-         "lc:departureDelay": "...",
-         "gtfs:trip":"...",
-         "lc:arrivalTime":"...",
-         "lc:departureTime":"...",
-         "lc:arrivalStop":"...",
-         "lc:departureStop":"..."
+        "@type": "tree:GreaterThanRelation",
+        "tree:node": "{next page}",
+        "tree:value": {
+          "@value": "«last-timestamp-we-have-in-this-page»",
+          "@type": "xsd:dateTime"
+        },
+        "tree:path": "dcterms:created"
+      },
+      {
+        "@type": "tree:LessThanRelation",
+        "tree:node": "{previous page}",
+        "tree:value": {
+          "@value": "«first-timestamp-we-have-in-this-page»",
+          "@type": "xsd:dateTime"
+        },
+        "tree:path": "dcterms:created"
+      },
+      {
+        "@type": "tree:GreaterThanRelation",
+        "tree:node": "{last page}",
+        "tree:value": {
+          "@value": "«based on the filename of the last file»",
+          "@type": "xsd:dateTime"
+        },
+        "tree:path": "dcterms:created"
       }
-    ],
-    "tree:view": {
-      "@id": "{current_page_id}",
-      "tree:relation": [
-        {
-          "@type": "tree:GreaterThanRelation",
-          "tree:node" : "{next page}",
-          "tree:value": {
-            "@value": "«last-timestamp-we-have-in-this-page»",
-            "@type": "xsd:dateTime"
-          },
-          "tree:path": "dcterms:created"
-       },
-       {
-         "@type": "tree:LessThanRelation",
-         "tree:node" : "{previous page}",
-         "tree:value": {
-           "@value": "«first-timestamp-we-have-in-this-page»",
-           "@type": "xsd:dateTime"
-         },
-         "tree:path": "dcterms:created"
-       },
-       {
-         "@type": "tree:GreaterThanRelation",
-         "tree:node" : "{last page}",
-         "tree:value": {
-           "@value": "«based on the filename of the last file»",
-           "@type": "xsd:dateTime"
-         },
-         "tree:path": "dcterms:created"
-       }
     ]
   }
 }
-

--- a/statics/skeleton-ldes.jsonld
+++ b/statics/skeleton-ldes.jsonld
@@ -5,9 +5,17 @@
     "lc": "http://semweb.mmlab.be/ns/linkedconnections#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "dcterms": "http://purl.org/dc/terms/",
+    "gtfs": "http://vocab.gtfs.org/terms#",
     "departureTime": {
       "@id": "lc:departureTime",
       "@type": "xsd:dateTime"
+    },
+    "created": {
+      "@id": "dcterms:created",
+      "@type": "xsd:dateTime"
+    },
+    "dcterms:isVersionOf": {
+      "@type": "@id"
     },
     "member": {
       "@id": "tree:member",
@@ -16,6 +24,24 @@
     "view": {
       "@type": "@id",
       "@id": "tree:view"
+    },
+    "gtfs:trip": {
+      "@type": "@id"
+    },
+    "gtfs:route": {
+      "@type": "@id"
+    },
+    "gtfs:pickupType": {
+      "@type": "@id"
+    },
+    "gtfs:dropOffType": {
+      "@type": "@id"
+    },
+    "gtfs:Regular": {
+      "@type": "@id"
+    },
+    "gtfs:NotAvailable": {
+      "@type": "@id"
     }
   },
   "@id": "https://{hostname}/{agency}/connections/feed",
@@ -26,7 +52,7 @@
       "@id": "https://{hostname}/{agency}/connections/{connectionid}/{version}",
       "@type": "lc:Connection",
       "dcterms:isVersionOf": "https://{hostname}/{agency}/connections/{connectionid}",
-      "dcterms:created": "2021-08-01T20:20:000Z",
+      "created": "2021-08-01T20:20:000Z",
       "lc:departureDelay": "...",
       "gtfs:trip": "...",
       "lc:arrivalTime": "...",
@@ -45,7 +71,7 @@
           "@value": "«last-timestamp-we-have-in-this-page»",
           "@type": "xsd:dateTime"
         },
-        "tree:path": "dcterms:created"
+        "tree:path": "created"
       },
       {
         "@type": "tree:LessThanRelation",
@@ -54,7 +80,7 @@
           "@value": "«first-timestamp-we-have-in-this-page»",
           "@type": "xsd:dateTime"
         },
-        "tree:path": "dcterms:created"
+        "tree:path": "created"
       },
       {
         "@type": "tree:GreaterThanRelation",
@@ -63,7 +89,7 @@
           "@value": "«based on the filename of the last file»",
           "@type": "xsd:dateTime"
         },
-        "tree:path": "dcterms:created"
+        "tree:path": "created"
       }
     ]
   }

--- a/statics/skeleton-ldes.jsonld
+++ b/statics/skeleton-ldes.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "tree":"https://w3id.org/tree#",
+    "ldes":"https://w3id.org/ldes#",
+    "lc": "http://semweb.mmlab.be/ns/linkedconnections#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dcterms" : "http://purl.org/dc/terms/",
+    "departureTime": {
+      "@id": "lc:departureTime",
+      "@type": "xsd:dateTime"
+    },
+    "member" :  {
+        "@id": "tree:member",
+        "@type": "@id"
+    },
+    "view": {
+      "@type":"@id",
+      "@id":"tree:view"
+    }
+  },
+  "@id": "https://{hostname}/{agency}/connections/feed",
+  "@type": "ldes:EventStream",
+  "tree:shape" : "{...}/connectionVersionShape.ttl",
+  "member": [
+      {
+         "@id": "https://{hostname}/{agency}/connections/{connectionid}/{version}",
+         "dcterms:isVersionOf": "https://{hostname}/{agency}/connections/{connectionid}",
+         "dcterms:created": "2021-08-01T20:20:000Z",
+         "@type": "lc:Connection",
+         "lc:departureDelay": "...",
+         "gtfs:trip":"...",
+         "lc:arrivalTime":"...",
+         "lc:departureTime":"...",
+         "lc:arrivalStop":"...",
+         "lc:departureStop":"..."
+      }
+    ],
+    "tree:view": {
+      "@id": "{current_page_id}",
+      "tree:relation": [
+        {
+          "@type": "tree:GreaterThanRelation",
+          "tree:node" : "{next page}",
+          "tree:value": {
+            "@value": "«last-timestamp-we-have-in-this-page»",
+            "@type": "xsd:dateTime"
+          },
+          "tree:path": "dcterms:created"
+       },
+       {
+         "@type": "tree:LessThanRelation",
+         "tree:node" : "{previous page}",
+         "tree:value": {
+           "@value": "«first-timestamp-we-have-in-this-page»",
+           "@type": "xsd:dateTime"
+         },
+         "tree:path": "dcterms:created"
+       },
+       {
+         "@type": "tree:GreaterThanRelation",
+         "tree:node" : "{last page}",
+         "tree:value": {
+           "@value": "«based on the filename of the last file»",
+           "@type": "xsd:dateTime"
+         },
+         "tree:path": "dcterms:created"
+       }
+    ]
+  }
+}
+

--- a/statics/skeleton-ldes.jsonld
+++ b/statics/skeleton-ldes.jsonld
@@ -42,6 +42,9 @@
     },
     "gtfs:NotAvailable": {
       "@type": "@id"
+    },
+    "tree:path": {
+      "@type": "@id"
     }
   },
   "@id": "https://{hostname}/{agency}/connections/feed",


### PR DESCRIPTION
This PR implements a `/feed` on top of the connections collection. The new `/feed` route will give you a full-history overview of all connections and follows the principles of Linked Data Event Streams.

This is the first step towards implementing the Linked Connections 2.0 specification