### PR TITLE
read transfer protocol from `server_config.json` instead of `req.protocol`

### DIFF
--- a/lib/routes/router.js
+++ b/lib/routes/router.js
@@ -41,8 +41,8 @@ feed.init().then(() => {
         console.log("originalUrl:", req.originalUrl);
 
         let shape = await utils.addSHACLMetadata({
-            "id": req.protocol + '://' + host + req.originalUrl,
-            "ldes": req.protocol + '://' + host + req.originalUrl.substring(0, req.originalUrl.indexOf("shape"))
+            "id": utils.serverConfig['protocol'] + '://' + host + req.originalUrl,
+            "ldes": utils.serverConfig['protocol'] + '://' + host + req.originalUrl.substring(0, req.originalUrl.indexOf("shape"))
         });
 
         res.set({'Content-Type': 'application/ld+json'});


### PR DESCRIPTION
fixes #82 

Co-authored-by: ryanbyloos <ryan.byloos@posteo.net>