### PR TITLE
`/connections/feed` extra pagination on `departureTime` for GTFS-RT data

### DIFF
--- a/lib/data/connections-feed.js
+++ b/lib/data/connections-feed.js
@@ -4,8 +4,6 @@ const watch = require('node-watch');
 const utils = require('../utils/utils');
 const AVLTree = require('../utils/avl-tree');
 const Logger = require('../utils/logger');
-// const RealTimeData = require('../data/real-time')
-// const StaticData = require('../data/static');
 
 const writeFile = util.promisify(fs.writeFile);
 const readFile = util.promisify(fs.readFile);
@@ -24,7 +22,7 @@ class ConnectionsFeed {
         this._watcher = null;
         this._recreateJob = null;
         this._latestVersion = null;
-        this._numberOfFragments = 100;
+        this._numberOfUpdates = 10;
     }
 
     async init() {
@@ -34,23 +32,26 @@ class ConnectionsFeed {
             // Make sure we start fresh
             this.clear();
 
-            // Create AVL Tree which will consist the 100 most recent fragments
+            // get an object with 'numberOfUpdates' of the most recent updates.
+            let updates = this.getCurrentUpdates(this.numberOfUpdates);
 
-            // get list of current fragments in feed_history
-            let fragments = await this.getSortedFragments();
-
-            // if necessary, cut the list down to 100 fragments
-            fragments.splice(this._numberOfFragments);
-
-            // load the ordered fragments and insert them into AVL tree
+            // load the updates drom disk and insert them into AVL tree
             const path = `${utils.datasetsConfig['storage']}/feed_history/${this.agency}`;
-            await Promise.all(fragments.map(async f => {
-                const fragment_date = new Date(f.substring(0, f.indexOf('.json')));
-                this.avlTree.insert(fragment_date.getTime(), JSON.parse(await readFile(`${path}/${fragment_date.toISOString()}.json`)));
+            await Promise.all(Object.keys(updates).map(async update => {
+                // parse and store all fragments in the update
+                const data = {};
+                await Promise.all(updates[update].map(async fragment => {
+                    const fragment_date = new Date(fragment);
+                    data[fragment_date.getTime()] = JSON.parse(await readFile(`${path}/${update}/${fragment_date.toISOString()}.json`));
+                }));
+
+                // insert update into AVL tree
+                const update_date = new Date(update);
+                this.avlTree.insert(update_date.getTime(), data);
             }));
 
-            logger.info(`Created feed AVL Tree for ${this.agency} (took ${(new Date().getTime() - start.getTime())} ms)`);
-            logger.debug(`Number of RT fragments inserted in ${this.agency} AVL Tree: ${fragments.length}`);
+            logger.info(`[feed] Created feed AVL Tree for ${this.agency} (took ${(new Date().getTime() - start.getTime())} ms)`);
+            logger.debug(`[feed] Number of RT updates inserted in ${this.agency} AVL Tree: ${Object.keys(updates).length}`);
 
             // Check for real-time updates by watching the latest.json file for real-time updates
             const latest = `${utils.datasetsConfig['storage']}/real_time/${this.agency}/latest.json`;
@@ -66,48 +67,91 @@ class ConnectionsFeed {
             });
 
         } catch (err) {
-            logger.error(err);
-            console.error(err);
+            logger.error('[feed] ' + err);
+            console.error('[feed]', err);
         }
     }
 
-    async getSortedFragments() {
-        // get list of current fragments in feed_history
-        let fragments = await readdir(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}`);
+    /**
+     * get the most recent RT update with its fragments
+     * @returns object with creation date of update as key and an array of data fragments in epoch time as value
+     */
+    async getNewestUpdate() {
+        let update_dirs = await readdir(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}`);
+        update_dirs.sort();
 
         // remove 'latest.json' if it exists
-        const latestIndex = fragments.indexOf("latest.json");
+        const latestIndex = update_dirs.indexOf("latest.json");
         if (latestIndex > -1) {
-            fragments.splice(latestIndex, 1);
+            update_dirs.splice(latestIndex, 1);
         }
 
-        // sort the list from newest to oldest date
-        fragments.sort();
+        const created = update_dirs[0];
 
-        return fragments;
+        // transform all fragments that are part of the update to Dates and store them
+        const fragment_names = await readdir(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${update_dir}`)
+        let fragments = []
+        fragment_names.forEach(f => {
+            const f_date = new Date(f.substring(0, f.indexOf(".json")));
+            fragments.push(f_date.getTime());
+        })
+
+        return {created: fragments};
+    }
+
+    /**
+     * get a certain amount of RT updates (with their fragments) by newest creation date
+     * @param quantity amount of updates to return
+     * @returns object with latest updates and their respective fragments
+     */
+    getCurrentUpdates(quantity) {
+        let updates = {};
+        let update_dirs = Object.keys(this.RTData.RTFragments[this.agency]);
+        update_dirs.sort();
+
+        // remove 'latest.json' if it exists
+        const latestIndex = update_dirs.indexOf("latest.json");
+        if (latestIndex > -1) {
+            update_dirs.splice(latestIndex, 1);
+        }
+
+        // get the necessary quantity of updates and find their respective fragments
+        update_dirs.slice(0, quantity);
+        update_dirs.forEach(update => updates[update] = this.RTData.RTFragments[this.agency][update]);
+
+        return updates;
     }
 
     async handleUpdate() {
         try {
-            let t0 = new Date();
+            let start = new Date();
+
             // check if AVL tree is 'full'
-            if (this.avlTree.size >= this.numberOfFragments) {
-                // if tree is full, delete oldest fragment
+            if (this.avlTree.size >= this.numberOfUpdates) {
+                // if tree is full, delete oldest update
                 this.avlTree.remove(this.avlTree.min(), this.avlTree.minNode())
             }
-            const fragments = await this.getSortedFragments();
-            // if tree is not full, just insert
-            const latestFragment = fragments[fragments.length - 1];
-            const newFragmentData = JSON.parse(await readFile(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${latestFragment}`));
-            const newFragmentDate = new Date(latestFragment.substring(0, latestFragment.indexOf(".json")));
-            this.avlTree.insert(newFragmentDate.getTime(), newFragmentData);
-            this.RTData.insertRTFragments(this.agency, latestFragment);
 
-            logger.debug(`-----------Update ${this.agency} AVL Tree-------------`);
-            logger.debug(`Load live data from disk took ${(new Date().getTime() - t0.getTime())} ms`);
+            const latest_update = await this.getNewestUpdate();
+            const update = Object.keys(latest_update)[0];
+
+            // parse and store all fragments in the update
+            const data = {};
+            await Promise.all(updates[update].map(async fragment => {
+                let fragment_date = new Date(fragment);
+                data[fragment_date.getTime()] = JSON.parse(await readFile(`${path}/${update}/${fragment_date.toISOString()}.json`));
+            }));
+
+            // insert update into AVL tree
+            const update_date = new Date(update);
+            this.avlTree.insert(update_date.getTime(), data);
+            await this.RTData.insertRTFragments(this.agency, update);
+
+            logger.debug(`[feed] -----------Update ${this.agency} AVL Tree-------------`);
+            logger.debug(`[feed] Load live data from disk took ${(new Date().getTime() - start.getTime())} ms`);
         } catch (err) {
-            logger.error(err);
-            console.error(err);
+            logger.error('[feed] ' + err);
+            console.error('[feed]', err);
         }
     }
 
@@ -180,12 +224,12 @@ class ConnectionsFeed {
         this._latestVersion = newVersion;
     }
 
-    get numberOfFragments() {
-        return this._numberOfFragments;
+    get numberOfUpdates() {
+        return this._numberOfUpdates;
     }
 
-    set numberOfFragments(numberOfFragments) {
-        this._numberOfFragments = numberOfFragments;
+    set numberOfUpdates(numberOfUpdates) {
+        this._numberOfUpdates = numberOfUpdates;
     }
 
     get RTData() {

--- a/lib/data/connections-feed.js
+++ b/lib/data/connections-feed.js
@@ -25,6 +25,12 @@ class ConnectionsFeed {
         this._numberOfUpdates = 10;
     }
 
+    /**
+     * initialise the connections feed by creating an AVL tree with real-time data and setting
+     * up a watcher that updates the tree when new updates arrive
+     *
+     * @returns {Promise<void>}
+     */
     async init() {
         try {
             const start = new Date();
@@ -32,10 +38,10 @@ class ConnectionsFeed {
             // Make sure we start fresh
             this.clear();
 
-            // get an object with 'numberOfUpdates' of the most recent updates.
+            // get <numberOfUpdates> of the most recent updates.
             let updates = this.getCurrentUpdates(this.numberOfUpdates);
 
-            // load the updates drom disk and insert them into AVL tree
+            // load the updates from disk and insert them into AVL tree
             const path = `${utils.datasetsConfig['storage']}/feed_history/${this.agency}`;
             await Promise.all(Object.keys(updates).map(async update => {
                 // parse and store all fragments in the update
@@ -50,16 +56,15 @@ class ConnectionsFeed {
                 this.avlTree.insert(update_date.getTime(), data);
             }));
 
-            logger.info(`[feed] Created feed AVL Tree for ${this.agency} (took ${(new Date().getTime() - start.getTime())} ms)`);
+            logger.info(` [feed] Created feed AVL Tree for ${this.agency} (took ${(new Date().getTime() - start.getTime())} ms)`);
             logger.debug(`[feed] Number of RT updates inserted in ${this.agency} AVL Tree: ${Object.keys(updates).length}`);
 
-            // Check for real-time updates by watching the latest.json file for real-time updates
-            const latest = `${utils.datasetsConfig['storage']}/real_time/${this.agency}/latest.json`;
+            // Check for real-time updates by watching the latest.json file
+            const latest = `${utils.datasetsConfig['storage']}/feed_history/${this.agency}/latest.json`;
             if (!fs.existsSync(latest)) {
                 await writeFile(latest, 'await for rt update', 'utf8');
             }
-
-            // add watcher that checks for updates in latest.json
+            // add watcher that checks for updates to latest.json
             this.watcher = watch(latest, (event, filename) => {
                 if (filename && event === 'update') {
                     this.handleUpdate();
@@ -73,12 +78,15 @@ class ConnectionsFeed {
     }
 
     /**
-     * get the most recent RT update with its fragments
-     * @returns object with creation date of update as key and an array of data fragments in epoch time as value
+     * get the most recent real-time update folder with its fragments
+     *
+     * @returns {Promise<{}>} object with creation date of update as key and an array of data
+     *                        fragments in epoch time as value
      */
     async getNewestUpdate() {
+        // get all updates
         let update_dirs = await readdir(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}`);
-        update_dirs.sort();
+        update_dirs.sort().reverse();
 
         // remove 'latest.json' if it exists
         const latestIndex = update_dirs.indexOf("latest.json");
@@ -86,28 +94,30 @@ class ConnectionsFeed {
             update_dirs.splice(latestIndex, 1);
         }
 
-        const created = update_dirs[0];
-
-        // transform all fragments that are part of the update to Dates and store them
-        const fragment_names = await readdir(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${update_dir}`)
+        // transform all fragments that are part of the update to dates in epoch time and store them
+        const fragment_names = await readdir(`${utils.datasetsConfig['storage']}/feed_history/${this.agency}/${update_dirs[0]}`)
         let fragments = []
         fragment_names.forEach(f => {
             const f_date = new Date(f.substring(0, f.indexOf(".json")));
             fragments.push(f_date.getTime());
-        })
+        });
 
-        return {created: fragments};
+        let result = {};
+        result[update_dirs[0]] = fragments
+
+        return result;
     }
 
     /**
-     * get a certain amount of RT updates (with their fragments) by newest creation date
+     * get a certain amount of the latest real-time update folders (and their fragments)
+     *
      * @param quantity amount of updates to return
-     * @returns object with latest updates and their respective fragments
+     * @returns {{}} object containing the latest updates and their respective fragments
      */
     getCurrentUpdates(quantity) {
         let updates = {};
         let update_dirs = Object.keys(this.RTData.RTFragments[this.agency]);
-        update_dirs.sort();
+        update_dirs.sort().reverse();
 
         // remove 'latest.json' if it exists
         const latestIndex = update_dirs.indexOf("latest.json");
@@ -116,28 +126,32 @@ class ConnectionsFeed {
         }
 
         // get the necessary quantity of updates and find their respective fragments
-        update_dirs.slice(0, quantity);
+        update_dirs = update_dirs.slice(0, quantity);
         update_dirs.forEach(update => updates[update] = this.RTData.RTFragments[this.agency][update]);
 
         return updates;
     }
 
+    /**
+     * handle update of real-time data by updating the AVL tree accordingly
+     * @returns {Promise<void>}
+     */
     async handleUpdate() {
         try {
             let start = new Date();
 
-            // check if AVL tree is 'full'
+            // if tree is full, delete oldest update
             if (this.avlTree.size >= this.numberOfUpdates) {
-                // if tree is full, delete oldest update
                 this.avlTree.remove(this.avlTree.min(), this.avlTree.minNode())
             }
 
             const latest_update = await this.getNewestUpdate();
             const update = Object.keys(latest_update)[0];
+            const path = `${utils.datasetsConfig['storage']}/feed_history/${this.agency}`;
 
             // parse and store all fragments in the update
             const data = {};
-            await Promise.all(updates[update].map(async fragment => {
+            await Promise.all(latest_update[update].map(async fragment => {
                 let fragment_date = new Date(fragment);
                 data[fragment_date.getTime()] = JSON.parse(await readFile(`${path}/${update}/${fragment_date.toISOString()}.json`));
             }));

--- a/lib/data/real-time.js
+++ b/lib/data/real-time.js
@@ -27,35 +27,49 @@ class RealTimeData {
             // Object for keeping fragment scan
             if (!this.RTFragments[companyName]) {
                 this.RTFragments[companyName] = {};
-                let dir = await readdir(this.storage + companyName);
-                let arr = [];
-                // Keep each fragment in milliseconds since epoch in the scan
-                for (let fragment of dir) {
-                    // check if file is 'latest.json'
-                    if (!(fragment === 'latest.json')) {
-                        // convert filename to epoch time
-                        let fragment_date = new Date(fragment.substring(0, fragment.indexOf('.json')));
+            }
+
+            // iterate over all update directories in the current company directory
+            let company_dir = await readdir(this.storage + companyName);
+            for (let update of company_dir) {
+                if ((update !== 'latest.json') && !this.RTFragments[companyName][update]) {
+                    // if 'update' is a directory, read all its file names and save these fragment indexes in epoch time
+                    let update_dir = await readdir(`${this.storage}${companyName}/${update}`);
+                    let arr = [];
+
+                    for (let file of update_dir) {
+                        // each file will be a fragment
+                        const fragment_date = new Date(file.substring(0, file.indexOf('.json')));
                         arr.push(fragment_date.getTime());
                     }
+
+                    // store the array of epoch indexes in RTFragments
+                    if (arr.length > 0) {
+                        arr.sort();
+                        this.RTFragments[companyName][update] = arr;
+                    }
                 }
-                if (arr.length > 0) {
-                    //sort the array
-                    arr.sort();
-                    this.RTFragments[companyName] = arr;
-                }
+
             }
         }
     }
 
     /**
-     * add newly created files to the 'RTFragments' index. To make sure that the array of fragments is still sorted
-     * after insertion, you should only insert new fragments.
-     * @param companyName name of agency where we inserted the new RT fragment
-     * @param fragment file name of the new fragment (ISO 8601 creation date with '.json' extension)
+     * add newly created files to the 'RTFragments' index. This method is called after every RT update (see 'connections-feed.js').
+     * @param companyName name of agency where we want to insert the new RT fragments
+     * @param update directory name of the new update (ISO 8601 creation date of update). This directory contains 
+     *               all of the update files sorted by departureTime (ISO 8601 creation date of update).
      */
-    insertRTFragments(companyName, fragment) {
-        let fragment_date = new Date(fragment.substring(0, fragment.indexOf('.json')));
-        this.RTFragments[companyName].push(fragment_date.getTime());
+    async insertRTFragments(companyName, update) {
+        let arr = [];
+        let update_dir = await readdir(`${this.storage}${companyName}/${update}`);
+        for (let file of update_dir) {
+            const fragment_date = new Date(file.substring(0, file.indexOf('.json')));
+            arr.push(fragment_date.getTime());
+        }
+        if (arr.length > 0) {
+            this.RTFragments[companyName][update] = arr;
+        }
     }
 
     get storage() {

--- a/lib/manager/dataset_manager.js
+++ b/lib/manager/dataset_manager.js
@@ -377,13 +377,7 @@ class DatasetManager {
                                 await writeFile(`${this.storage}/feed_history/${dataset['companyName']}/latest.json`, JSON.stringify(rawData), 'utf8'),
                                 await writeFile(`${this.storage}/real_time/${dataset['companyName']}/latest.json`, JSON.stringify(rawData), 'utf8')
                             ]));
-
-                        // await writeFile(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}.json`, JSON.stringify(rawData), 'utf8');
-                        // // now, write the new data from the buffer to 'latest.json'
-                        // fs.copyFileSync(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}.json`, `${this.storage}/feed_history/${dataset['companyName']}/latest.json`);
-                        // // Write to disk the complete list of updated Connections
-                        // await writeFile(`${this.storage}/real_time/${dataset['companyName']}/latest.json`, JSON.stringify(rawData), 'utf8');
-
+                            
                         // Update rt fragments
                         await Promise.all(rawData.map(async jodata => {
                             // Determine current fragment that the connection belongs to, due to delays

--- a/lib/manager/dataset_manager.js
+++ b/lib/manager/dataset_manager.js
@@ -355,12 +355,34 @@ class DatasetManager {
                         // write data to buffer (a buffer is just a json file named after the current time, and will
                         // contain the newest update)
                         const now = new Date();
-                        await writeFile(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}.json`, JSON.stringify(rawData), 'utf8');
-                        // now, write the new data from the buffer to 'latest.json'
-                        fs.copyFileSync(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}.json`, `${this.storage}/feed_history/${dataset['companyName']}/latest.json`);
 
-                        // Write to disk the complete list of updated Connections
-                        await writeFile(`${this.storage}/real_time/${dataset['companyName']}/latest.json`, JSON.stringify(rawData), 'utf8');
+                        // sort the raw data objects by departureTime, so that we can easily paginate on this later
+                        rawData.sort((a, b) => (a.departureTime > b.departureTime) ? 1 : ((b.departureTime > a.departureTime) ? -1 : 0));
+
+                        // split rawData into chunks of 100 objects
+                        const chunks = Array.from(
+                            new Array(Math.ceil(rawData.length / 100)),
+                            (_, i) => rawData.slice(i * 100, i * 100 + 100)
+                        );
+
+                        // create a new folder where all current updates will be stored
+                        fs.mkdirSync(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}`);
+
+                        // write all of these chunks to separate files, then write rawData to the latest.json files
+                        await Promise.all(chunks.map(async chunk => {
+                            const departure_time = new Date(chunk[0].departureTime).toISOString();
+                            await writeFile(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}/${departure_time}.json`, JSON.stringify(chunk), 'utf8');
+                        }))
+                            .then(await Promise.all([
+                                await writeFile(`${this.storage}/feed_history/${dataset['companyName']}/latest.json`, JSON.stringify(rawData), 'utf8'),
+                                await writeFile(`${this.storage}/real_time/${dataset['companyName']}/latest.json`, JSON.stringify(rawData), 'utf8')
+                            ]));
+
+                        // await writeFile(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}.json`, JSON.stringify(rawData), 'utf8');
+                        // // now, write the new data from the buffer to 'latest.json'
+                        // fs.copyFileSync(`${this.storage}/feed_history/${dataset['companyName']}/${now.toISOString()}.json`, `${this.storage}/feed_history/${dataset['companyName']}/latest.json`);
+                        // // Write to disk the complete list of updated Connections
+                        // await writeFile(`${this.storage}/real_time/${dataset['companyName']}/latest.json`, JSON.stringify(rawData), 'utf8');
 
                         // Update rt fragments
                         await Promise.all(rawData.map(async jodata => {

--- a/lib/routes/feed.js
+++ b/lib/routes/feed.js
@@ -29,13 +29,19 @@ class Feed {
     constructor() {
         this._storage = utils.datasetsConfig.storage;
         this._datasets = utils.datasetsConfig.datasets;
-        this._serverConfig = utils.serverConfig;
     }
 
+    /**
+     * creates indexes for each dataset of static and real-time data and creates an AVL tree with the real-time data
+     * @returns {Promise<void>}
+     */
     async init() {
-        // Create static fragments index structure
-        await staticData.updateStaticFragments(); // TODO check if this can be done concurrently with initRTFragments()
-        await RTData.initRTFragments();
+        // Create static and RT fragments index structure
+        await Promise.all([
+            await staticData.updateStaticFragments(),
+            await RTData.initRTFragments()
+        ]);
+
         // Create an AVL tree-based index of Connections for every data source
         for (const d of this.datasets) {
             const tree = new ConnectionsFeed({staticData: staticData, RTData: RTData, agency: d['companyName']});
@@ -51,7 +57,6 @@ class Feed {
         // Determine protocol (i.e. HTTP or HTTPS)
         let x_forwarded_proto = req.headers['x-forwarded-proto'];
         let protocol = '';
-
         if (typeof x_forwarded_proto == 'undefined' || x_forwarded_proto == '') {
             if (typeof server_config.protocol == 'undefined' || server_config.protocol == '') {
                 protocol = 'http';
@@ -61,13 +66,11 @@ class Feed {
         } else {
             protocol = x_forwarded_proto;
         }
-
         const host = protocol + '://' + server_config.hostname + '/';
 
         // Request path and query parameters
         const agency = req.params.agency;
-        let created = new Date(decodeURIComponent(req.query.created));
-        // query can have a departureTime if and only if we request static data
+        let created = (req.query.created != null) ? new Date(decodeURIComponent(req.query.created)) : new Date();
         let departure_time = new Date(decodeURIComponent(req.query.departureTime));
 
         // TODO: use path to avoid OS compatibility issues and handle the trailing slash
@@ -81,154 +84,153 @@ class Feed {
         // Accept header
         const accept = accepts(req).type(mimeTypes);
 
-        // Redirect to NOW time in case provided date is invalid
-        if (created.toString() === 'Invalid Date') {
-            // Just save to a variable, a redirect will automatically follow since this won't
-            // perfectly resolve to an existing page
-            created = new Date();
-        }
-
-        // Redirect to proper URL if final / is given before params
-        if (req.url.indexOf('connections/feed/') >= 0) {
-            res.location(`/${agency}/connections/feed?created=${created.toISOString()}`);
-            res.status(302).send();
-            return;
-        }
-
         try {
-            // Find the fragment that covers the requested time
-            let t0 = new Date();
-            let [found_fragment, index, is_static] = utils.findFeedResource(agency, created.getTime(), RTData.RTFragments, staticData.staticFragments);
-            logger.debug('finding fragment took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+            // Find the directory name (either a static version or a RT update) that covers the requested time
+            let t0 = new Date(); // time how long it takes to find a fragment
+            let [dir_name, _, is_static] = utils.findFeedResource(agency, created.toISOString(), RTData.RTFragments, staticData.staticFragments);
 
-            // Redirect client to the appropriate fragment URL
-            if (created.getTime() !== found_fragment) {
-                let found_fragment_date = new Date(found_fragment);
-                res.location('/' + agency + '/connections/feed?created=' + found_fragment_date.toISOString());
+            // Redirect client to the appropriate fragment URL if necessary
+            if (created.toISOString() !== dir_name) {
+                let found_update_date = new Date(dir_name);
+                res.location('/' + agency + '/connections/feed?created=' + found_update_date.toISOString());
                 res.status(302).send();
                 return;
             }
 
-            // find and retrieve the actual data contained in that fragment
-            let members, id, previous, next, latest, next_departure;
-            members = id = previous = next = latest = next_departure = null;
-            let tree = feedTrees[agency].avlTree;
-            // get latest page (or rightmost node in AVL tree)
-            latest = tree.max();
-            if (!is_static) {
-                // since fragment is a real-time fragment, check if it is in the AVL tree
-                if (created.getTime() >= tree.min() && created.getTime() <= tree.max()) {
-                    const node = tree.find(created.getTime());
-                    members = node.data;
-                    id = node.key;
-                } else {
-                    // if fragment is not in the AVL tree, get it from the directory.
-                    members = JSON.parse(await readFile(`${storage}/feed_history/${agency}/${created.toISOString()}.json`));
-                    id = created.getTime();
-                }
-
-                // get previous page
-                if (index > 0) {
-                    previous = RTData.RTFragments[agency][index - 1];
-                } else {
-                    // if index === 0, then previous is in the static data
-                    const static_versions = Object.keys(staticData.staticFragments[agency]).sort();
-                    previous = static_versions[static_versions.length - 1];
-                }
-
-                // get next page
-                if (index < RTData.RTFragments[agency].length - 1) {
-                    next = RTData.RTFragments[agency][index + 1];
-                }
-
-                // we don't need departure_time with real-time data
-                departure_time = null;
-            } else {
-                // data is static, so get it from the directory (since we don't store static data in the AVL tree).
-                // NOTE: when providing static data, we paginate the LDES by 'created' time (aka the different static
-                // versions) AND by 'departure_time'.
-
-                // first, make sure that we have a valid departure_time
-                if (departure_time.toString() === 'Invalid Date') {
-                    // if we don't have a departure time yet, we take the first departure time in the current
-                    // version of static data
+            // make sure that we have a valid departure_time
+            if (departure_time.toString() === 'Invalid Date') {
+                // if we don't have a valid departure_time, we take the departure time from the first fragment (either
+                // from the RT or static data)
+                if (is_static) {
                     departure_time = new Date(staticData.staticFragments[agency][created.toISOString()][0]);
-                    res.location(`/${agency}/connections/feed?created=${created.toISOString()}&departureTime=${departure_time.toISOString()}`);
-                    res.status(302).send();
-                    return;
+                } else {
+                    departure_time = new Date(RTData.RTFragments[agency][created.toISOString()][0]);
                 }
-                // now that we have a valid departure time, we look for a matching fragment
-                let [_, static_fragment, static_index] = utils.findResource(agency, departure_time.getTime(), [created.toISOString()], staticData.staticFragments);
+                // once we have a valid date, we redirect
+                res.location(`/${agency}/connections/feed?created=${created.toISOString()}&departureTime=${departure_time.toISOString()}`);
+                res.status(302).send();
+                return;
+            }
 
-                const static_fragment_date = new Date(static_fragment);
-                // Redirect client to the appropriate fragment URL
-                if (departure_time.getTime() !== static_fragment) {
-                    res.location(`/${agency}/connections/feed?created=${created.toISOString()}&departureTime=${static_fragment_date.toISOString()}`);
-                    res.status(302).send();
-                    return;
+            // find the fragment name and its index
+            let fragment, fragment_index;
+            if (!is_static) {
+                [_, fragment, fragment_index] = utils.findRTResource(agency, departure_time.getTime(), created.toISOString(), RTData.RTFragments);
+            } else {
+                [_, fragment, fragment_index] = utils.findResource(agency, departure_time.getTime(), [created.toISOString()], staticData.staticFragments);
+            }
+
+            // Redirect client to the appropriate fragment URL if necessary
+            const fragment_date = new Date(fragment);
+            if (departure_time.getTime() !== fragment) {
+                res.location(`/${agency}/connections/feed?created=${created.toISOString()}&departureTime=${fragment_date.toISOString()}`);
+                res.status(302).send();
+                return;
+            }
+
+            logger.debug('[feed] finding fragment took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+            t0 = new Date(); // time how long it takes to retrieve the found fragment
+
+            // retrieve the fragment data from disk or AVL tree
+            let tree = feedTrees[agency].avlTree;
+            let members;
+            if (!is_static) {
+                if (created.getTime() >= tree.min() && created.getTime() <= tree.max()) {
+                    // get RT data fragment from AVL tree
+                    const node = tree.find(created.getTime());
+                    members = node.data[fragment_date.getTime()];
+                } else {
+                    // get RT data fragment from disk
+                    const path = `${storage}/feed_history/${agency}/${created.toISOString()}/${fragment_date.toISOString()}.json`;
+                    members = JSON.parse(await readFile(path));
+                }
+            } else {
+                // get static data fragment from disk
+                const path = `${storage}/linked_pages/${agency}/${created.toISOString()}/${fragment_date.toISOString()}.jsonld.gz`;
+                members = JSON.parse(`[${await utils.readAndGunzip(path)}]`);
+            }
+
+            logger.debug('[feed] retrieving fragment took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+            t0 = new Date(); // time how long it takes to create a LDES page with metadata using the fragment
+
+            // create the necessary parameters to build a page
+            let id = created.getTime();
+            let latest, previous, next, next_departure;
+            latest = previous = next = next_departure = null;
+            const versions = Object.keys(staticData.staticFragments[agency]).sort();
+            const updates = Object.keys(RTData.RTFragments[agency]).sort();
+
+            // 'latest', 'previous' and 'next' can only be set when we are on the first page
+            // of the version or update
+            if (fragment_index === 0) {
+                // latest
+                latest = tree.max();
+                if (latest === null) {
+                    // if there is no RT data, 'latest' is the last static version
+                    const latest_date = new Date(versions[versions.length - 1]);
+                    latest = latest_date.getTime();
                 }
 
-                // get fragment data from disk
-                let static_path = storage + '/linked_pages/' + agency + '/' + created.toISOString();
-                members = JSON.parse('[' + await utils.readAndGunzip(`${static_path}/${static_fragment_date.toISOString()}.jsonld.gz`) + ']');
-                id = created.getTime();
+                // previous and next
+                if (is_static) {
+                    const version_index = versions.indexOf(created.toISOString());
 
-                // get previous and next version if possible and necessary
-                if (static_index === 0) {
-                    const static_versions = Object.keys(staticData.staticFragments[agency]).sort();
-                    const version_index = static_versions.indexOf(created.toISOString());
-
-                    if (latest === null) {
-                        // if there is no real-time latest page, then we set the newest static data version to latest
-                        const latest_date = new Date(static_versions[static_versions.length - 1]);
-                        latest = latest_date.getTime();
-                    }
-
-                    // if we are on the first departureTime fragment and there is a previous static version,
-                    // then we set previous
+                    // if there is a previous static version, we set previous
                     if (version_index > 0) {
-                        previous = static_versions[version_index - 1];
+                        previous = versions[version_index - 1];
                     }
 
-                    // if we are on the first departureTime fragment and there is a next static or real-time version,
-                    // then we set next
-                    if (version_index < static_versions.length - 1) {
-                        next = static_versions[version_index + 1];
-                    } else if (version_index === static_versions.length - 1 && RTData.RTFragments[agency].length > 0) {
-                        next = RTData.RTFragments[agency][0];
+                    // if there is a next static or real-time version, we set next
+                    if (version_index < versions.length - 1) {
+                        next = versions[version_index + 1];
+                    } else if (version_index === versions.length - 1 && updates.length > 0) {
+                        next = updates[0];
                     }
-                }
+                } else {
+                    const update_index = updates.indexOf(created.toISOString());
 
-                // get next departure time fragment if possible
-                const static_fragments = staticData.staticFragments[agency][created.toISOString()];
-                if (static_index < static_fragments.length - 1) {
-                    next_departure = static_fragments[static_index + 1];
+                    // if there is a previous real-time or static version, we set previous
+                    if (update_index > 0) {
+                        previous = updates[update_index - 1];
+                    } else if (update_index === 0 && versions.length > 0) {
+                        previous = versions[versions.length - 1];
+                    }
+
+                    // if there is a next real-time version, we set next
+                    if (update_index < updates.length - 1) {
+                        next = updates[update_index + 1];
+                    }
                 }
             }
 
-            members.forEach( (member, index) => {
+            // next_departure
+            const fragments = (is_static) ? staticData.staticFragments[agency][created.toISOString()] : RTData.RTFragments[agency][created.toISOString()];
+            if (fragment_index < fragments.length - 1) {
+                next_departure = fragments[fragment_index + 1];
+            }
+
+            members.forEach((member) => {
                 member["isVersionOf"] = member["@id"];
                 member["@id"] += `/${created.toISOString()}`;
                 member["created"] = created.toISOString();
             });
 
-            departure_time = (departure_time !== null) ? departure_time.getTime() : null;
+            departure_time = departure_time.getTime();
 
             const params = {
                 host: host,
                 agency: agency,
-                members: members,       // connections
-                id: id,                 // epoch time of created
+                members: members,       // array of connections
+                created: id,            // epoch time of created
                 previous: previous,     // epoch time of previous fragment
                 next: next,             // epoch time of next fragment
                 latest: latest,         // epoch time of latest fragment
-                isStatic: is_static,
-                departureTime: departure_time,
-                nextDeparture: next_departure,
+                isStatic: is_static,    // says if requested page is static or real-time data
+                departureTime: departure_time,  // departureTime of first connection in current fragment
+                nextDeparture: next_departure,  // departureTime of first connection in next fragment
             };
 
             // create LDES page
-            t0 = new Date();
             let final_data = await utils.addLDESMetadata(params);
 
             res.set({'Vary': 'Accept, Accept-Encoding, Accept-Datetime'});
@@ -275,17 +277,16 @@ class Feed {
                     break;
             }
 
-            logger.debug('Add Metadata took ' + (new Date().getTime() - t0.getTime()) + ' ms');
+            logger.debug('[feed] Creating page + adding metadata took ' + (new Date().getTime() - t0.getTime()) + ' ms');
 
         } catch (err) {
             if (err) {
-                logger.error(err);
+                logger.error('[feed] ' + err);
                 console.error(err);
             }
             res.set({'Cache-Control': 'no-cache'});
             res.status(404).send();
         }
-
     }
 
     getDataset(name) {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -592,7 +592,7 @@ module.exports = new class Utils {
 
     async addSHACLMetadata(params) {
         try {
-            let template = await readFile('./statics/shape.json', {encoding: 'utf8'});
+            let template = await readFile('./statics/shape.jsonld', {encoding: 'utf8'});
             let shape = JSON.parse(template);
 
             let id = params.id;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -85,29 +85,25 @@ module.exports = new class Utils {
     }
 
     /**
-     * find the closest real-time fragment to the left of a given target date.
-     *
-     * @param agency
-     * @param target
-     * @param RTFragments
-     * @returns {null}
+     * find closest real-time fragment to the left of a given target date in an update directory.
+     * @param agency agency name of dataset we are searching
+     * @param target target date (in epoch notation) of wanted fragment
+     * @param update directory name of the update (ISO 8601 creation date of update)
+     * @param RTFragments index that keeps track of all real-time data fragments
+     * @returns {*[]} an array containing update dir, fragment name and fragment index
      */
-    findRTResource(agency, target, RTFragments) {
+    findRTResource(agency, target, update, RTFragments) {
         let fragment = null;
-        let fragments = RTFragments[agency];
+        let fragments = RTFragments[agency][update];
 
-        if (target >= fragments[0]) {
+        // Checking that target date is contained in the list of fragments.
+        if (target >= fragments[0] && target <= fragments[fragments.length - 1]) {
             fragment = this.binarySearch(target, fragments);
-            if (fragment === null) {
-                // if fragment is null after binary search, then just refer to the latest fragment
-                fragment = [fragments[fragments.length - 1], fragments.length - 1]
+            if (fragment !== null) {
+                return [update, fragment[0], fragment[1]]
             }
         }
-        if (fragment !== null) {
-            return fragment;
-        } else {
-            throw new Error('Fragment not found in current data');
-        }
+        throw new Error('Fragment not found in real-time data');
     }
 
     // Search for a given fragment across the different static versions
@@ -131,45 +127,38 @@ module.exports = new class Utils {
         if (version !== null && fragment !== null) {
             return version.concat(fragment);
         } else {
-            throw new Error('Fragment not found in current data');
+            throw new Error('Fragment not found in static data');
         }
     }
 
     /**
-     * Find the fragment that has the closest creation date to the left of a given target date.
-     * We first look in the real-time fragments, then we look in the staticFragments (if necessary).
+     * Find the closest directory with creation date to the left of a given target date.
+     * We first look in the real-time fragments for an update directory, then we look in the static
+     * fragments for a version directory.
      *
-     * @param agency the company for which we are finding a fragment
-     * @param target the target date. We look for the fragment with the closest creation date to the
-     *               left of this target date.
-     * @param RTFragments index for real-time data fragments
-     * @param staticFragments index for static data fragments
+     * @param agency the company name for which we are finding a directory
+     * @param target name of wanted directory (creation date in ISO 8601 notation)
+     * @param RTFragments index that keeps track of all real-time data fragments
+     * @param staticFragments index that keeps track of all static data fragments
+     * @returns {(*|boolean)[]} an array containing folder name, folder index and a bool that says
+     *                          whether the folder contains static or real-time data fragments
      */
     findFeedResource(agency, target, RTFragments, staticFragments) {
-        let is_static;
-        let rt_min = RTFragments[agency][0];
-        // let rt_max = RTFragments[agency][RTFragments[agency].length - 1];
+        // sort static versions and RT updates from oldest to newest date
+        let updates = Object.keys(RTFragments[agency]).sort();
+        let versions = Object.keys(staticFragments[agency]).sort();
 
         try {
-            // first, check if the fragment can be found in the real-time fragments
-            if (target >= rt_min) {
-                // if target date is in range of real-time data, get the closest fragment to the left of it
-                let result = this.findRTResource(agency, target, RTFragments);
-                is_static = false;
-                return [result[0], result[1], is_static]
-            }
+            // is_static tells us whether we have to search in the static or RT data
+            let is_static = !(target >= updates[0]);
+            let index_array = is_static ? versions : updates;
 
-            // the fragment wasn't found in the real-time data, so now we look in the static data
-            let versions = Object.keys(staticFragments[agency]).sort().map(ver => new Date(ver).getTime());
-            let result = this.binarySearch(target, versions);
-            if (result !== null) {
-                // if target date is in range of static data, get the closest fragment to the left of it
-                is_static = true;
-                return [result[0], result[1], is_static]
-            } else {
-                is_static = true;
-                return [versions[versions.length - 1], versions.length - 1, is_static]
+            let result = this.binarySearch(target, index_array);
+            if (result === null) {
+                // if result is null, refer to the last folder name in the index
+                result = [index_array[index_array.length - 1], index_array.length - 1]
             }
+            return [result[0], result[1], is_static]
         } catch (err) {
             // if an exception occurred, throw it again so we can handle it
             throw err;
@@ -517,7 +506,7 @@ module.exports = new class Utils {
             let host = params.host;
             let agency = params.agency;
             let members = params.members; // connections
-            let id = new Date(params.id); // epoch time of created
+            let created = new Date(params.created); // epoch time of created
             let next = (params.next !== null) ? new Date(params.next) : null; // epoch time of next fragment
             let previous = (params.previous !== null) ? new Date(params.previous) : null; // epoch time of previous fragment
             let latest = (params.latest !== null) ? new Date(params.latest) : null; // epoch time of latest fragment
@@ -530,13 +519,9 @@ module.exports = new class Utils {
 
             let departureTime = (params.departureTime !== null) ? new Date(params.departureTime) : null;
             let nextDeparture = (params.nextDeparture !== null) ? new Date(params.nextDeparture) : null;
-            let dt = "";
-            let ndt = "";
 
-            if (is_static) {
-                dt = (departureTime !== null) ? "&departureTime=" + departureTime.toISOString() : "";
-                ndt = (nextDeparture !== null) ? "&departureTime=" + nextDeparture.toISOString() : "";
-            }
+            let dt = (departureTime !== null) ? "&departureTime=" + departureTime.toISOString() : "";
+            let ndt = (nextDeparture !== null) ? "&departureTime=" + nextDeparture.toISOString() : "";
 
             ldes['@id'] = host + agency + '/connections/feed';
             ldes['tree:shape'] = host + agency + '/connections/feed/shape';
@@ -545,14 +530,14 @@ module.exports = new class Utils {
                 ldes['member'].push(member);
             }
 
-            ldes['tree:view']['@id'] = host + agency + `/connections/feed?created=${id.toISOString()}` + dt;
+            ldes['tree:view']['@id'] = host + agency + `/connections/feed?created=${created.toISOString()}` + dt;
 
             let treeRelations = [];
             // next departure time
-            if (is_static && (nextDeparture !== null)) {
+            if (nextDeparture !== null) {
                 treeRelations.push({
                     "@type": "tree:GreaterThanRelation",
-                    "tree:node": host + agency + `/connections/feed?created=${id.toISOString()}` + ndt,
+                    "tree:node": host + agency + `/connections/feed?created=${created.toISOString()}` + ndt,
                     "tree:value": {
                         "@value": `${departureTime.toISOString()}`,
                         "@type": "xsd:dateTime"
@@ -566,7 +551,7 @@ module.exports = new class Utils {
                     "@type": "tree:GreaterThanRelation",
                     "tree:node": host + agency + `/connections/feed?created=${next.toISOString()}`,
                     "tree:value": {
-                        "@value": `${id.toISOString()}`,
+                        "@value": `${created.toISOString()}`,
                         "@type": "xsd:dateTime"
                     },
                     "tree:path": "dcterms:created"
@@ -578,19 +563,19 @@ module.exports = new class Utils {
                     "@type": "tree:LessThanRelation",
                     "tree:node": host + agency + `/connections/feed?created=${previous.toISOString()}`,
                     "tree:value": {
-                        "@value": `${id.toISOString()}`,
+                        "@value": `${created.toISOString()}`,
                         "@type": "xsd:dateTime"
                     },
                     "tree:path": "dcterms:created"
                 });
             }
             // latest created
-            if ((latest !== null) && (latest.getTime() !== id.getTime()) && (!is_static)) {
+            if ((latest !== null) && (latest.getTime() !== created.getTime())) {
                 treeRelations.push({
                     "@type": "tree:GreaterThanRelation",
                     "tree:node": host + agency + `/connections/feed?created=${latest.toISOString()}`,
                     "tree:value": {
-                        "@value": `${id.toISOString()}`,
+                        "@value": `${created.toISOString()}`,
                         "@type": "xsd:dateTime"
                     },
                     "tree:path": "dcterms:created"

--- a/statics/shape.jsonld
+++ b/statics/shape.jsonld
@@ -6,7 +6,7 @@
     "ldes": "https://w3id.org/ldes#",
     "lc": "http://semweb.mmlab.be/ns/linkedconnections#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "dct": "http://purl.org/dc/terms/",
+    "dcterms": "http://purl.org/dc/terms/",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "gtfs": "http://vocab.gtfs.org/terms#",
     "shapeOf": {
@@ -26,10 +26,6 @@
     "sh:class": {
       "@type": "@id"
     },
-    "departureTime": {
-      "@id": "lc:departureTime",
-      "@type": "xsd:dateTime"
-    },
     "created": {
       "@id": "dcterms:created",
       "@type": "xsd:dateTime"
@@ -37,13 +33,33 @@
     "dcterms:isVersionOf": {
       "@type": "@id"
     },
-    "member": {
-      "@id": "tree:member",
-      "@type": "@id"
-    },
-    "view": {
+    "departureStop": {
       "@type": "@id",
-      "@id": "tree:view"
+      "@id": "lc:departureStop"
+    },
+    "arrivalStop": {
+      "@type": "@id",
+      "@id": "lc:arrivalStop"
+    },
+    "departureTime": {
+      "@id": "lc:departureTime",
+      "@type": "xsd:dateTime"
+    },
+    "arrivalTime": {
+      "@id": "lc:arrivalTime",
+      "@type": "xsd:dateTime"
+    },
+    "departureDelay": {
+      "@id": "lc:departureDelay",
+      "@type": "xsd:integer"
+    },
+    "arrivalDelay": {
+      "@id": "lc:arrivalDelay",
+      "@type": "xsd:integer"
+    },
+    "direction": {
+      "@id": "gtfs:headsign",
+      "@type": "xsd:string"
     },
     "gtfs:trip": {
       "@type": "@id"
@@ -62,6 +78,14 @@
     },
     "gtfs:NotAvailable": {
       "@type": "@id"
+    },
+    "member": {
+      "@id": "tree:member",
+      "@type": "@id"
+    },
+    "view": {
+      "@type": "@id",
+      "@id": "tree:view"
     }
   },
   "@id": "",
@@ -69,20 +93,13 @@
   "shapeOf": "",
   "sh:property": [
     {
-      "sh:path": "dct:isVersionOf",
+      "sh:path": "dcterms:isVersionOf",
       "sh:nodeKind": "sh:IRI",
       "sh:minCount": "1",
       "sh:maxCount": "1"
     },
     {
-      "sh:path": "dct:created",
-      "sh:nodeKind": "sh:Literal",
-      "sh:datatype": "xsd:dateTime",
-      "sh:minCount": "1",
-      "sh:maxCount": "1"
-    },
-    {
-      "sh:path": "lc:departureTime",
+      "sh:path": "dcterms:created",
       "sh:nodeKind": "sh:Literal",
       "sh:datatype": "xsd:dateTime",
       "sh:minCount": "1",
@@ -96,8 +113,16 @@
       "sh:maxCount": "1"
     },
     {
-      "sh:path": "lc:departureDelay",
+      "sh:path": "lc:arrivalStop",
+      "sh:nodeKind": "sh:IRI",
+      "sh:class": "gtfs:Stop",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "lc:departureTime",
       "sh:nodeKind": "sh:Literal",
+      "sh:datatype": "xsd:dateTime",
       "sh:minCount": "1",
       "sh:maxCount": "1"
     },
@@ -109,15 +134,24 @@
       "sh:maxCount": "1"
     },
     {
-      "sh:path": "lc:arrivalStop",
-      "sh:nodeKind": "sh:IRI",
-      "sh:class": "gtfs:Stop",
+      "sh:path": "lc:departureDelay",
+      "sh:nodeKind": "sh:Literal",
+      "sh:datatype": "xsd:integer",
       "sh:minCount": "1",
       "sh:maxCount": "1"
     },
     {
       "sh:path": "lc:arrivalDelay",
       "sh:nodeKind": "sh:Literal",
+      "sh:datatype": "xsd:integer",
+      "sh:minCount": "1",
+      "sh:maxCount": "1"
+    },
+    {
+      "sh:path": "gtfs:headsign",
+      "sh:nodeKind": "sh:Literal",
+      "sh:class": "gtfs:Headsign",
+      "sh:datatype": "xsd:string",
       "sh:minCount": "1",
       "sh:maxCount": "1"
     },

--- a/statics/skeleton-ldes.jsonld
+++ b/statics/skeleton-ldes.jsonld
@@ -6,9 +6,22 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "dcterms": "http://purl.org/dc/terms/",
     "gtfs": "http://vocab.gtfs.org/terms#",
-    "departureTime": {
-      "@id": "lc:departureTime",
-      "@type": "xsd:dateTime"
+    "member": {
+      "@id": "tree:member",
+      "@type": "@id"
+    },
+    "view": {
+      "@type": "@id",
+      "@id": "tree:view"
+    },
+    "tree:path": {
+      "@type": "@id"
+    },
+    "tree:node": {
+      "@type": "@id"
+    },
+    "tree:shape": {
+      "@type": "@id"
     },
     "created": {
       "@id": "dcterms:created",
@@ -17,14 +30,34 @@
     "isVersionOf": {
       "@id": "dcterms:isVersionOf",
       "@type": "@id"
-    },
-    "member": {
-      "@id": "tree:member",
-      "@type": "@id"
-    },
-    "view": {
+      },
+    "departureStop": {
       "@type": "@id",
-      "@id": "tree:view"
+      "@id": "lc:departureStop"
+    },
+    "arrivalStop": {
+      "@type": "@id",
+      "@id": "lc:arrivalStop"
+    },
+    "departureTime": {
+      "@id": "lc:departureTime",
+      "@type": "xsd:dateTime"
+    },
+    "arrivalTime": {
+      "@id": "lc:arrivalTime",
+      "@type": "xsd:dateTime"
+    },
+    "departureDelay": {
+      "@id": "lc:departureDelay",
+      "@type": "xsd:integer"
+    },
+    "arrivalDelay": {
+      "@id": "lc:arrivalDelay",
+      "@type": "xsd:integer"
+    },
+    "direction": {
+      "@id": "gtfs:headsign",
+      "@type": "xsd:string"
     },
     "gtfs:trip": {
       "@type": "@id"
@@ -42,15 +75,6 @@
       "@type": "@id"
     },
     "gtfs:NotAvailable": {
-      "@type": "@id"
-    },
-    "tree:path": {
-      "@type": "@id"
-    },
-    "tree:node": {
-      "@type": "@id"
-    },
-    "tree:shape": {
       "@type": "@id"
     }
   },


### PR DESCRIPTION
- changed file structure for real-time data in `feed_history`
- updated real-time index and AVL tree to support new fragmentation
- updated `/connections/feed` route such that it also paginates real-time data on `departureTime`